### PR TITLE
Feat: OAuth2 로그인 및 JWT 기반 인증/인가 기능 구현

### DIFF
--- a/roome/.gitignore
+++ b/roome/.gitignore
@@ -46,7 +46,5 @@ redis/
 **/generated/
 
 ### .env ###
+.env
 **/resources/.env
-
-### Secret configuration file ###
-application-secret.yml

--- a/roome/build.gradle
+++ b/roome/build.gradle
@@ -40,10 +40,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
-	//JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/roome/src/main/java/com/roome/domain/oauth2/dto/KakaoResponse.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/dto/KakaoResponse.java
@@ -1,15 +1,27 @@
 package com.roome.domain.oauth2.dto;
 
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
 import java.util.Map;
 
 public class KakaoResponse implements OAuth2Response {
 
     private final Map<String, Object> attributes;
-    private final Map<String, Object> properties;
+    private final Map<String, Object> kakaoAccount;
+    private final Map<String, Object> profile;
 
     public KakaoResponse(Map<String, Object> attributes) {
         this.attributes = attributes;
-        this.properties = (Map<String, Object>) attributes.get("properties");
+
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        if (this.kakaoAccount == null) {
+            throw new OAuth2AuthenticationException("카카오 계정 정보가 없습니다.");
+        }
+
+        this.profile = (Map<String, Object>) kakaoAccount.get("profile");
+        if (this.profile == null) {
+            throw new OAuth2AuthenticationException("카카오 프로필 정보가 없습니다.");
+        }
     }
 
     @Override
@@ -19,16 +31,22 @@ public class KakaoResponse implements OAuth2Response {
 
     @Override
     public String getProviderId() {
-        return attributes.get("id").toString();
+        Object id = attributes.get("id");
+        if (id == null) {
+            throw new OAuth2AuthenticationException("카카오 ID가 없습니다.");
+        }
+        return id.toString();
     }
 
     @Override
     public String getName() {
-        return properties.get("nickname").toString();
+        Object nickname = profile.get("nickname");
+        return nickname != null ? nickname.toString() : "Unknown";
     }
 
     @Override
     public String getProfileImageUrl() {
-        return attributes.get("profile_image").toString();
+        Object profileImage = profile.get("profile_image_url");
+        return profileImage != null ? profileImage.toString() : null;
     }
 }

--- a/roome/src/main/java/com/roome/domain/oauth2/dto/OAuth2UserPrincipal.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/dto/OAuth2UserPrincipal.java
@@ -1,5 +1,6 @@
 package com.roome.domain.oauth2.dto;
 
+import com.roome.domain.user.entity.User;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -12,11 +13,13 @@ import java.util.Map;
 
 @Getter
 public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
+    private final User user;
     private final OAuth2Response oAuth2Response;
     private final Collection<? extends GrantedAuthority> authorities;
     private final Map<String, Object> attributes;
 
-    public OAuth2UserPrincipal(OAuth2Response oAuth2Response) {
+    public OAuth2UserPrincipal(User user, OAuth2Response oAuth2Response) {
+        this.user = user;
         this.oAuth2Response = oAuth2Response;
         this.authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
         this.attributes = Collections.singletonMap("user", oAuth2Response);
@@ -34,7 +37,7 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
 
     @Override
     public String getName() {
-        return oAuth2Response.getName();
+        return user.getName();
     }
 
     @Override
@@ -44,7 +47,7 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
 
     @Override
     public String getUsername() {
-        return oAuth2Response.getProviderId();
+        return user.getProviderId();
     }
 
     @Override

--- a/roome/src/main/java/com/roome/domain/oauth2/exception/AuthenticationFailedException.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/exception/AuthenticationFailedException.java
@@ -1,0 +1,10 @@
+package com.roome.domain.oauth2.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class AuthenticationFailedException extends BusinessException {
+    public AuthenticationFailedException() {
+        super(ErrorCode.AUTHENTICATION_FAILED);
+    }
+}

--- a/roome/src/main/java/com/roome/domain/oauth2/exception/DisabledAccountException.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/exception/DisabledAccountException.java
@@ -1,0 +1,10 @@
+package com.roome.domain.oauth2.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class DisabledAccountException extends BusinessException {
+    public DisabledAccountException() {
+        super(ErrorCode.DISABLED_ACCOUNT);
+    }
+}

--- a/roome/src/main/java/com/roome/domain/oauth2/exception/InvalidLoginException.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/exception/InvalidLoginException.java
@@ -1,0 +1,10 @@
+package com.roome.domain.oauth2.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class InvalidLoginException extends BusinessException {
+    public InvalidLoginException() {
+        super(ErrorCode.INVALID_LOGIN);
+    }
+}

--- a/roome/src/main/java/com/roome/domain/oauth2/exception/Oauth2AuthenticationErrorException.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/exception/Oauth2AuthenticationErrorException.java
@@ -1,0 +1,10 @@
+package com.roome.domain.oauth2.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class Oauth2AuthenticationErrorException extends BusinessException {
+    public Oauth2AuthenticationErrorException() {
+        super(ErrorCode.OAUTH2_AUTHENTICATION_ERROR);
+    }
+}

--- a/roome/src/main/java/com/roome/domain/oauth2/exception/UnsupportedOAuth2ProviderException.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/exception/UnsupportedOAuth2ProviderException.java
@@ -1,0 +1,10 @@
+package com.roome.domain.oauth2.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class UnsupportedOAuth2ProviderException extends BusinessException {
+    public UnsupportedOAuth2ProviderException() {
+        super(ErrorCode.UNSUPPORTED_OAUTH2_PROVIDER);
+    }
+}

--- a/roome/src/main/java/com/roome/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/service/CustomOAuth2UserService.java
@@ -1,37 +1,76 @@
 package com.roome.domain.oauth2.service;
 
-import com.roome.domain.oauth2.dto.*;
+import com.roome.domain.oauth2.dto.OAuth2Response;
+import com.roome.domain.oauth2.dto.OAuth2UserPrincipal;
+import com.roome.domain.user.entity.Provider;
+import com.roome.domain.user.entity.Status;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+@Slf4j
+@RequiredArgsConstructor
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        System.out.println(oAuth2User);
+        return processOAuth2User(userRequest, oAuth2User);
+    }
 
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        OAuth2Response oAuth2Response = null;
+    private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+        try {
 
-        switch (registrationId) {
-            case "naver":
-                oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
-                break;
-            case "google":
-                oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
-                break;
-            case "kakao":
-                oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
-                break;
-            default:
-                throw new OAuth2AuthenticationException("지원하지 않는 로그인 방식입니다.");
+            OAuth2Response oAuth2Response = OAuth2Factory.getProvider(
+                    userRequest.getClientRegistration().getRegistrationId(),
+                    oAuth2User.getAttributes()
+            );
+
+            // 사용자 정보 저장 or 업데이트
+            User user = updateOrCreateUser(oAuth2Response);
+            return new OAuth2UserPrincipal(user, oAuth2Response);
+
+        } catch (AuthenticationException e) {
+            log.error("OAuth2 인증 실패: {}", e.getMessage(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("OAuth2 처리 중 내부 오류: {}", e.getMessage());
+            throw new InternalAuthenticationServiceException(e.getMessage(), e.getCause());
         }
+    }
 
-        return new OAuth2UserPrincipal(oAuth2Response);
+    private User updateOrCreateUser(OAuth2Response oAuth2Response) {
+        return userRepository.findByProviderId(oAuth2Response.getProviderId())
+                .map(user -> {
+                    updateUser(user, oAuth2Response);
+                    return user;
+                })
+                .orElseGet(() -> userRepository.save(createUser(oAuth2Response)));
+    }
+
+    private User createUser(OAuth2Response response) {
+        return User.builder()
+                .name(response.getName())             // 소셜에서 가져온 이름
+                .nickname(response.getName())         // 초기 닉네임은 소셜 이름으로 설정
+                .profileImage(response.getProfileImageUrl())
+                .provider(Provider.valueOf(response.getProvider().name()))
+                .providerId(response.getProviderId())
+                .status(Status.OFFLINE)
+                .build();
+    }
+
+    private void updateUser(User user, OAuth2Response response) {
+        user.updateProfile(response.getName(), response.getProfileImageUrl(), user.getBio());
     }
 }

--- a/roome/src/main/java/com/roome/domain/oauth2/service/OAuth2Factory.java
+++ b/roome/src/main/java/com/roome/domain/oauth2/service/OAuth2Factory.java
@@ -1,0 +1,22 @@
+package com.roome.domain.oauth2.service;
+
+import com.roome.domain.oauth2.dto.*;
+import com.roome.domain.oauth2.exception.UnsupportedOAuth2ProviderException;
+
+import java.util.Map;
+
+public class OAuth2Factory {
+
+    public static OAuth2Response getProvider(String registrationId, Map<String, Object> attributes) {
+        if (OAuth2Provider.GOOGLE.getRegistrationId().equals(registrationId)) {
+            return new GoogleResponse(attributes);
+        } else if (OAuth2Provider.NAVER.getRegistrationId().equals(registrationId)) {
+            return new NaverResponse(attributes);
+        } else if (OAuth2Provider.KAKAO.getRegistrationId().equals(registrationId)) {
+            return new KakaoResponse(attributes);
+        } else {
+            throw new UnsupportedOAuth2ProviderException();
+        }
+    }
+}
+

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .successHandler(oAuth2SuccessHandler)
                         .failureHandler(oAuth2FailureHandler))
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/login/**", "/oauth2/**").permitAll()
+                        .requestMatchers("/", "/login/**", "/oauth2/**", "/api/auth/**").permitAll()
                         .anyRequest().authenticated());
 
         http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -1,57 +1,60 @@
 package com.roome.global.config;
 
+import com.roome.global.jwt.filter.JwtAuthenticationFilter;
+import com.roome.global.jwt.handler.OAuth2FailureHandler;
+import com.roome.global.jwt.handler.OAuth2SuccessHandler;
 import com.roome.domain.oauth2.service.CustomOAuth2UserService;
+import com.roome.global.jwt.service.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final JwtTokenProvider jwtTokenProvider;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+
+    @Bean
+    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+        return new HttpSessionOAuth2AuthorizationRequestRepository();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        //csrf disable
         http
-                .csrf((auth) -> auth.disable());
-
-        //From 로그인 방식 disable
-        http
-                .formLogin((auth) -> auth.disable());
-
-        //HTTP Basic 인증 방식 disable
-        http
-                .httpBasic((auth) -> auth.disable());
-
-        //oauth2
-        http
-                .oauth2Login(Customizer.withDefaults());
-
-        //oauth2
-        http
-                .oauth2Login((oauth2) -> oauth2
-                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)));
-
-        //경로별 인가 작업
-        http
+                .csrf((auth) -> auth.disable())
+                .formLogin((auth) -> auth.disable())
+                .httpBasic((auth) -> auth.disable())
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .authorizationRequestRepository(authorizationRequestRepository()))
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler))
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/", "/login/**", "/oauth2/**").permitAll()
                         .anyRequest().authenticated());
 
-        //세션 설정 : STATELESS
-        http
-                .sessionManagement((session) -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter.class
+        );
 
         return http.build();
     }

--- a/roome/src/main/java/com/roome/global/exception/BusinessException.java
+++ b/roome/src/main/java/com/roome/global/exception/BusinessException.java
@@ -5,11 +5,10 @@ import lombok.Getter;
 @Getter
 public class BusinessException extends RuntimeException {
 
-  private final ErrorCode errorCodes;
+  private final ErrorCode errorCode;
 
-  public BusinessException(ErrorCode errorCodes) {
-    super(errorCodes.getMessage());
-    this.errorCodes = errorCodes;
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
   }
-
 }

--- a/roome/src/main/java/com/roome/global/exception/ErrorCode.java
+++ b/roome/src/main/java/com/roome/global/exception/ErrorCode.java
@@ -17,7 +17,11 @@ public enum ErrorCode {
 
   // JWT 관련 예외
   INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT 토큰이 유효하지 않거나, 입력값이 비어 있습니다."),
-  MISSING_AUTHORITY(HttpStatus.UNAUTHORIZED, "해당 토큰에는 권한 정보가 포함되어 있지 않습니다.")
+  INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."),
+  MISSING_AUTHORITY(HttpStatus.UNAUTHORIZED, "해당 토큰에는 권한 정보가 포함되어 있지 않습니다."),
+
+  // User 관련 예외
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.")
   ;
 
   private final HttpStatus status;

--- a/roome/src/main/java/com/roome/global/exception/ErrorCode.java
+++ b/roome/src/main/java/com/roome/global/exception/ErrorCode.java
@@ -7,8 +7,19 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+
+  // OAuth2 로그인 관련 예외
+  UNSUPPORTED_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 로그인 방식입니다."),
+  AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+  OAUTH2_AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "소셜 로그인 인증 중 오류가 발생했습니다."),
+  INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
+  DISABLED_ACCOUNT(HttpStatus.FORBIDDEN, "비활성화된 계정입니다."),
+
+  // JWT 관련 예외
+  INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT 토큰이 유효하지 않거나, 입력값이 비어 있습니다."),
+  MISSING_AUTHORITY(HttpStatus.UNAUTHORIZED, "해당 토큰에는 권한 정보가 포함되어 있지 않습니다.")
   ;
 
-  private final String message;
   private final HttpStatus status;
+  private final String message;
 }

--- a/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
+++ b/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ public class GlobalExceptionHandler {
   // 비즈니스 관련 예러 처리
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<ErrorResponse> handleCustomException(BusinessException e) {
-    ErrorCode error = e.getErrorCodes();
+    ErrorCode error = e.getErrorCode();
     return ResponseEntity
         .status(error.getStatus())
         .body(new ErrorResponse(error.getMessage(), error.getStatus().toString()));

--- a/roome/src/main/java/com/roome/global/jwt/controller/AuthController.java
+++ b/roome/src/main/java/com/roome/global/jwt/controller/AuthController.java
@@ -1,0 +1,45 @@
+package com.roome.global.jwt.controller;
+
+import com.roome.global.jwt.dto.JwtToken;
+import com.roome.global.jwt.helper.TokenResponseHelper;
+import com.roome.global.jwt.service.TokenService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final TokenService tokenService;
+    private final TokenResponseHelper tokenResponseHelper;
+
+    @PostMapping("/reissue-token")
+    public ResponseEntity<?> reissueToken(
+            @CookieValue("refresh_token") String refreshToken,
+            HttpServletResponse response
+    ) {
+        JwtToken newToken = tokenService.reissueToken(refreshToken);
+        tokenResponseHelper.setTokenResponse(response, newToken);
+
+        return ResponseEntity.ok(createTokenResponse(newToken));
+    }
+
+    private Map<String, Object> createTokenResponse(JwtToken token) {
+        return Map.of(
+                "access_token", token.getAccessToken(),
+                "token_type", token.getGrantType(),
+                "expires_in", 3600,
+                "message", "토큰이 재발급되었습니다."
+        );
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/dto/JwtToken.java
+++ b/roome/src/main/java/com/roome/global/jwt/dto/JwtToken.java
@@ -1,0 +1,14 @@
+package com.roome.global.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class JwtToken {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/roome/src/main/java/com/roome/global/jwt/exception/InvalidJwtTokenException.java
+++ b/roome/src/main/java/com/roome/global/jwt/exception/InvalidJwtTokenException.java
@@ -1,0 +1,10 @@
+package com.roome.global.jwt.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class InvalidJwtTokenException extends BusinessException {
+    public InvalidJwtTokenException() {
+        super(ErrorCode.INVALID_JWT_TOKEN);
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/exception/InvalidRefreshTokenException.java
+++ b/roome/src/main/java/com/roome/global/jwt/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.roome.global.jwt.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class InvalidRefreshTokenException extends BusinessException {
+    public InvalidRefreshTokenException() {
+        super(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/exception/MissingAuthorityException.java
+++ b/roome/src/main/java/com/roome/global/jwt/exception/MissingAuthorityException.java
@@ -1,0 +1,10 @@
+package com.roome.global.jwt.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class MissingAuthorityException extends BusinessException {
+    public MissingAuthorityException() {
+        super(ErrorCode.MISSING_AUTHORITY);
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/exception/UserNotFoundException.java
+++ b/roome/src/main/java/com/roome/global/jwt/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.roome.global.jwt.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class UserNotFoundException extends BusinessException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/roome/src/main/java/com/roome/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.roome.global.jwt.filter;
+
+import com.roome.global.jwt.service.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        // 유효한 토큰이면 인증 정보 설정
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    // 요청 헤더에서 토큰 정보 추출
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/handler/OAuth2FailureHandler.java
+++ b/roome/src/main/java/com/roome/global/jwt/handler/OAuth2FailureHandler.java
@@ -1,0 +1,58 @@
+package com.roome.global.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+
+        log.error("로그인 실패: {}, 요청 경로: {}", exception.getMessage(), request.getRequestURI(), exception);
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+
+        String errorType = "인증 실패";
+        String errorMessage = exception.getMessage();
+
+        if (exception instanceof OAuth2AuthenticationException) {
+            OAuth2AuthenticationException oauthException = (OAuth2AuthenticationException) exception;
+            errorType = "OAuth2 인증 오류";
+            errorMessage = "소셜 로그인 인증 중 오류가 발생했습니다: " + oauthException.getError().getErrorCode();
+        } else if (exception instanceof BadCredentialsException) {
+            errorType = "잘못된 인증 정보";
+            errorMessage = "아이디 또는 비밀번호가 일치하지 않습니다.";
+        } else if (exception instanceof DisabledException) {
+            errorType = "비활성화된 계정";
+            errorMessage = "해당 계정이 비활성화되었습니다.";
+        }
+
+        response.getWriter().write(
+                new ObjectMapper().writeValueAsString(
+                        Map.of(
+                                "error", errorType,
+                                "message", errorMessage,
+                                "timestamp", System.currentTimeMillis(),
+                                "path", request.getRequestURI()
+                        )
+                )
+        );
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/handler/OAuth2FailureHandler.java
+++ b/roome/src/main/java/com/roome/global/jwt/handler/OAuth2FailureHandler.java
@@ -1,10 +1,16 @@
 package com.roome.global.jwt.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roome.domain.oauth2.exception.AuthenticationFailedException;
+import com.roome.domain.oauth2.exception.DisabledAccountException;
+import com.roome.domain.oauth2.exception.InvalidLoginException;
+import com.roome.domain.oauth2.exception.Oauth2AuthenticationErrorException;
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.AuthenticationException;
@@ -13,11 +19,13 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -25,34 +33,36 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
         log.error("로그인 실패: {}, 요청 경로: {}", exception.getMessage(), request.getRequestURI(), exception);
 
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.setContentType("application/json");
-        response.setCharacterEncoding("utf-8");
+        try {
+            BusinessException businessException = convertToBusinessException(exception);
 
-        String errorType = "인증 실패";
-        String errorMessage = exception.getMessage();
+            response.setStatus(businessException.getErrorCode().getStatus().value());
+            response.setContentType("application/json");
+            response.setCharacterEncoding("utf-8");
 
-        if (exception instanceof OAuth2AuthenticationException) {
-            OAuth2AuthenticationException oauthException = (OAuth2AuthenticationException) exception;
-            errorType = "OAuth2 인증 오류";
-            errorMessage = "소셜 로그인 인증 중 오류가 발생했습니다: " + oauthException.getError().getErrorCode();
-        } else if (exception instanceof BadCredentialsException) {
-            errorType = "잘못된 인증 정보";
-            errorMessage = "아이디 또는 비밀번호가 일치하지 않습니다.";
-        } else if (exception instanceof DisabledException) {
-            errorType = "비활성화된 계정";
-            errorMessage = "해당 계정이 비활성화되었습니다.";
+            ErrorResponse errorResponse = new ErrorResponse(
+                    businessException.getErrorCode().getMessage(),
+                    businessException.getErrorCode().getStatus().toString()
+            );
+
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+
+        } catch (Exception e) {
+            log.error("예외 처리 중 오류 발생", e);
+            throw e;
         }
+    }
 
-        response.getWriter().write(
-                new ObjectMapper().writeValueAsString(
-                        Map.of(
-                                "error", errorType,
-                                "message", errorMessage,
-                                "timestamp", System.currentTimeMillis(),
-                                "path", request.getRequestURI()
-                        )
-                )
-        );
+    // 커스텀 예외
+    private BusinessException convertToBusinessException(AuthenticationException exception) {
+        if (exception instanceof OAuth2AuthenticationException) {
+            return new Oauth2AuthenticationErrorException();
+        } else if (exception instanceof BadCredentialsException) {
+            return new InvalidLoginException();
+        } else if (exception instanceof DisabledException) {
+            return new DisabledAccountException();
+        } else {
+            return new AuthenticationFailedException();
+        }
     }
 }

--- a/roome/src/main/java/com/roome/global/jwt/handler/OAuth2SuccessHandler.java
+++ b/roome/src/main/java/com/roome/global/jwt/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,50 @@
+package com.roome.global.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roome.global.jwt.dto.JwtToken;
+import com.roome.global.jwt.service.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        // Jwt 생성
+        JwtToken token = jwtTokenProvider.createToken(authentication);
+
+        // 쿠키에 Refresh Token 저장
+        Cookie refreshTokenCookie = new Cookie("refresh_token", token.getRefreshToken());
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        response.addCookie(refreshTokenCookie);
+
+        // Access Token을 헤더에 추가
+        response.addHeader("Authorization", "Bearer " + token.getAccessToken());
+
+        Map<String, Object> tokenResponse = Map.of(
+                "access_token", token.getAccessToken(),
+                "token_type", token.getGrantType(),
+                "expires_in", 3600,
+                "message", "토큰이 발급되었습니다."
+        );
+
+        // Access Token을 json으로 전송
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(tokenResponse));
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/helper/TokenResponseHelper.java
+++ b/roome/src/main/java/com/roome/global/jwt/helper/TokenResponseHelper.java
@@ -1,0 +1,29 @@
+package com.roome.global.jwt.helper;
+
+import com.roome.global.jwt.dto.JwtToken;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenResponseHelper {
+    private static final int REFRESH_TOKEN_EXPIRE_TIME = 14 * 24 * 60 * 60; // 14일
+
+    public void setTokenResponse(HttpServletResponse response, JwtToken token) {
+        setRefreshTokenCookie(response, token.getRefreshToken());
+        setAccessTokenHeader(response, token.getAccessToken());
+    }
+
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(REFRESH_TOKEN_EXPIRE_TIME);
+        response.addCookie(refreshTokenCookie);
+    }
+
+    private void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.addHeader("Authorization", "Bearer " + accessToken);
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/service/JwtTokenProvider.java
+++ b/roome/src/main/java/com/roome/global/jwt/service/JwtTokenProvider.java
@@ -1,0 +1,68 @@
+package com.roome.global.jwt.service;
+
+import com.roome.global.jwt.dto.JwtToken;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14; // 14일
+
+    private SecretKey secretKey;
+
+    @Value("${spring.jwt.secret}")
+    private String secret;
+
+    @PostConstruct
+    protected void init() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // User 정보로 Access Token 생성
+    public JwtToken createToken(Authentication authentication) {
+
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/service/JwtTokenProvider.java
+++ b/roome/src/main/java/com/roome/global/jwt/service/JwtTokenProvider.java
@@ -1,27 +1,33 @@
 package com.roome.global.jwt.service;
 
 import com.roome.global.jwt.dto.JwtToken;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1시간
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14; // 14일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;             // 1시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
 
     private SecretKey secretKey;
 
@@ -64,5 +70,57 @@ public class JwtTokenProvider {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+
+        // Jwt 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("해당 토큰에는 권한 정보가 포함되어 있지 않습니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // UserDetails 객체를 생성 후 Authentication return
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 정보 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("서명이 올바르지 않거나 변조된 JWT 토큰입니다.", e);
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 형식의 JWT 토큰입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 유효하지 않거나, 입력값이 비어 있습니다.", e);
+        }
+        return false;
+    }
+
+    // Access Token
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
     }
 }

--- a/roome/src/main/java/com/roome/global/jwt/service/TokenService.java
+++ b/roome/src/main/java/com/roome/global/jwt/service/TokenService.java
@@ -1,0 +1,59 @@
+package com.roome.global.jwt.service;
+
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import com.roome.global.jwt.dto.JwtToken;
+import com.roome.global.jwt.exception.InvalidRefreshTokenException;
+import com.roome.global.jwt.exception.UserNotFoundException;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    public JwtToken reissueToken(String refreshToken) {
+        validateRefreshToken(refreshToken);
+        User user = findUserByRefreshToken(refreshToken);
+        verifyRefreshTokenMatch(refreshToken, user);
+
+        // 단순히 사용자 ID만 포함
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                user.getProviderId(),
+                null,
+                Collections.emptyList()  // 권한 없이 빈 리스트로 설정
+        );
+        return jwtTokenProvider.createToken(authentication);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            log.warn("Refresh Token 검증 실패: {}", refreshToken);
+            throw new InvalidRefreshTokenException();
+        }
+    }
+
+    private User findUserByRefreshToken(String refreshToken) {
+        Claims claims = jwtTokenProvider.parseClaims(refreshToken);
+        String userId = claims.getSubject();
+
+        return userRepository.findByProviderId(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    private void verifyRefreshTokenMatch(String refreshToken, User user) {
+        if (!refreshToken.equals(user.getRefreshToken())) {
+            throw new InvalidRefreshTokenException();
+        }
+    }
+}

--- a/roome/src/main/resources/application.yml
+++ b/roome/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
+  profiles:
+    active: test
   config:
-    import: optional:application-secret.yml
+    import: optional:file:.env[.properties]
   security:
     oauth2:
       client:
@@ -29,6 +31,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
             scope:
               - profile_nickname
               - profile_image
@@ -43,8 +46,8 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-  profiles:
-    active: test  # 기본 프로필을 local로 지정
+  jwt:
+    secret: ${JWT_SECRET}
 
 server:
   shutdown: graceful


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)
Feat: OAuth2 로그인 및 JWT 기반 인증/인가 기능 구현

### ✅ PR 설명
- OAuth2 로그인 후 JWT를 발급하고, 이를 이용한 인증 및 인가 로직 구축
- Refresh Token을 이용한 Access Token 재발급 기능 추가

### 🏗 작업 내용
- [ ] OAuth2 로그인 & JWT 발급
- [ ] JWT 인증 및 인가
- [ ] 토큰 재발급 기능

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.
#3, #4, #5 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
