### PR TITLE
feat: CD 관련 엔티티 추가

### DIFF
--- a/roome/src/main/java/com/roome/domain/cd/entity/Cd.java
+++ b/roome/src/main/java/com/roome/domain/cd/entity/Cd.java
@@ -1,0 +1,49 @@
+package com.roome.domain.cd.entity;
+
+import com.roome.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "cd")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cd extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String title; // CD 제목
+
+  @Column(nullable = false)
+  private String artist; // 가수
+
+  @Column(nullable = false)
+  private String album; // 앨범명
+
+  @Column(nullable = false)
+  private String genre; // 장르
+
+  @Column(nullable = false)
+  private String coverUrl; // 앨범 커버 이미지 URL
+
+  @Column(nullable = false, unique = true)
+  private String youtubeVideoId; // 유튜브 영상 ID
+
+  @Column(nullable = false)
+  private int duration; // 영상 길이 (초 단위)
+
+  public Cd(String title, String artist, String album, String genre, String coverUrl, String youtubeVideoId, int duration) {
+    this.title = title;
+    this.artist = artist;
+    this.album = album;
+    this.genre = genre;
+    this.coverUrl = coverUrl;
+    this.youtubeVideoId = youtubeVideoId;
+    this.duration = duration;
+  }
+}

--- a/roome/src/main/java/com/roome/domain/cd/entity/CdComment.java
+++ b/roome/src/main/java/com/roome/domain/cd/entity/CdComment.java
@@ -1,0 +1,40 @@
+package com.roome.domain.cd.entity;
+
+import com.roome.global.entity.BaseEntity;
+import com.roome.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "cd_comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CdComment extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cd_player_id", nullable = false)
+  private CdPlayer cdPlayer; // 특정 CDPlayer (CD 목록) 에 대한 댓글
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user; // 댓글 작성자
+
+  @Column(nullable = false, length = 500)
+  private String comment; // 댓글 내용
+
+  @Column(nullable = true)
+  private Integer timestampSec; // 특정 시간 (초 단위, null 가능)
+
+  public CdComment(CdPlayer cdPlayer, User user, String comment, Integer timestampSec) {
+    this.cdPlayer = cdPlayer;
+    this.user = user;
+    this.comment = comment;
+    this.timestampSec = timestampSec;
+  }
+}

--- a/roome/src/main/java/com/roome/domain/cd/entity/CdPlayer.java
+++ b/roome/src/main/java/com/roome/domain/cd/entity/CdPlayer.java
@@ -1,0 +1,37 @@
+package com.roome.domain.cd.entity;
+
+import com.roome.global.entity.BaseEntity;
+import com.roome.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "cd_player")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CdPlayer extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user; // 사용자가 추가한 CD
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cd_id", nullable = false)
+  private Cd cd; // CD 정보
+
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime addedAt = LocalDateTime.now(); // 추가한 시간
+
+  public CdPlayer(User user, Cd cd) {
+    this.user = user;
+    this.cd = cd;
+  }
+}

--- a/roome/src/main/java/com/roome/domain/cd/entity/CdTemplate.java
+++ b/roome/src/main/java/com/roome/domain/cd/entity/CdTemplate.java
@@ -1,0 +1,42 @@
+package com.roome.domain.cd.entity;
+
+import com.roome.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "cd_template")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CdTemplate extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cd_player_id", nullable = false)
+  private CdPlayer cdPlayer; // 사용자가 추가한 CD (1:1 관계)
+
+  @Column(nullable = false, length = 500)
+  private String reason; // CD를 듣게 된 계기
+
+  @Column(nullable = false, length = 500)
+  private String bestPart; // 가장 좋았던 부분
+
+  @Column(nullable = false, length = 500)
+  private String emotion; // 들으면서 느낀 감정
+
+  @Column(nullable = false, length = 500)
+  private String frequentSituation; // 자주 듣는 상황
+
+  public CdTemplate(CdPlayer cdPlayer, String reason, String bestPart, String emotion, String frequentSituation) {
+    this.cdPlayer = cdPlayer;
+    this.reason = reason;
+    this.bestPart = bestPart;
+    this.emotion = emotion;
+    this.frequentSituation = frequentSituation;
+  }
+}


### PR DESCRIPTION
## 📌 feat: CD 관련 엔티티 추가

### ✅ PR 설명
- 엔티티 클래스 작성

### 🏗 작업 내용
- Cd 엔티티 생성 (사용자가 추가한 CD 정보 저장)
- CdPlayer 엔티티 생성 (사용자의 CD 플레이어 - CD 목록)
- CdTemplate 엔티티 생성 (CD에 대한 템플릿)
- CdComment 엔티티 생성 (CD에 대한 댓글)

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> #10 

### 🚨 참고 사항 (선택)
> 이슈에서 작성했던 엔티티에서 필요 없는 엔티티 삭제, 이름 수정
