### PR TITLE
Feat: 스웨거 연동

### DIFF
--- a/roome/build.gradle
+++ b/roome/build.gradle
@@ -44,7 +44,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-}
+
+	// SWAGGER
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -64,7 +64,11 @@ public class SecurityConfig {
                                 "/login/oauth2/code/*",
                                 "/oauth2/authorization/*",
                                 "/api/auth/**",
-                                "/error"
+                                "/error",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/api/**"
                         ).permitAll()
                         .anyRequest().authenticated());
 

--- a/roome/src/main/java/com/roome/global/config/SwaggerConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package com.roome.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    /**
+     * OpenAPI Bean을 생성하여 애플리케이션의 OpenAPI 문서 구성을 제공합니다.
+     *
+     * @return OpenAPI OpenAPI 설정 객체
+     */
+    private Info info() {
+        return new Info()
+                .title("RoomE ")
+                .version("1.0")
+                .description("API 명세서");
+    }
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("access-token", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("access-token"))
+                .info(info());
+    }
+}

--- a/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
+++ b/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice
+//@RestControllerAdvice
 public class GlobalExceptionHandler {
 
   // 비즈니스 관련 예러 처리


### PR DESCRIPTION
### ✅ PR 설명
스웨거 연동 해뒀습니다.

### 🏗 작업 내용
- [x] 스웨거 의존성 추가
- [x] 스웨거 config 추가
- [x] security에서 스웨거 및 api/** 제외

### 🚨 참고 사항 (선택)
> 기존 500 에러는 swagger와 spring boot 버전이 호환이 안 돼서 발생하던 거였는데, 해결 방법이 없다고 합니다 ..ㅎㅎ
스프링 부트 버전을 낮추는 방법 말고는 `GlobalExceptionHandler`에 있는 `@RestControllerAdvice`를 주석처리 해서 임시로 제거 해주는게 있는데, 이렇게 하면 에러 코드가 상당히 길고 지저분하게 나오게 됩니다 ㅠㅠ ..
`@RestControllerAdvice` 이거 때문에 충돌이 발생하는 거라서 스웨거로 확인하실 땐 저 부분 주석처리 하고 사용하시고, 그 외에는 다시 주석 해제해서 에러코드 정상적으로 나오게 계속 바꿔줘야 할 듯 합니다 ....

