### PR TITLE
AuthController 테스트 추가

### DIFF
--- a/roome/src/main/java/com/roome/domain/auth/dto/oauth2/OAuth2Provider.java
+++ b/roome/src/main/java/com/roome/domain/auth/dto/oauth2/OAuth2Provider.java
@@ -34,16 +34,6 @@ public enum OAuth2Provider {
         throw new InvalidProviderException();
     }
 
-    public Map<String, String> getTokenRequest(String authorizationCode) {
-        return Map.of(
-                "grant_type", "authorization_code",
-                "client_id", googleClientId,
-                "client_secret", googleClientSecret,
-                "code", authorizationCode,
-                "redirect_uri", googleRedirectUri
-        );
-    }
-
     public String getUserInfoUri(String accessToken) {
         return userInfoUri + "?access_token=" + accessToken;
     }

--- a/roome/src/main/java/com/roome/domain/auth/dto/request/LoginRequest.java
+++ b/roome/src/main/java/com/roome/domain/auth/dto/request/LoginRequest.java
@@ -8,4 +8,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginRequest {
     private String code;
+
+    public LoginRequest(String code) {
+        this.code = code;
+    }
 }

--- a/roome/src/main/java/com/roome/domain/auth/exception/MissingAuthorizationCodeException.java
+++ b/roome/src/main/java/com/roome/domain/auth/exception/MissingAuthorizationCodeException.java
@@ -1,0 +1,13 @@
+package com.roome.domain.auth.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class MissingAuthorizationCodeException extends BusinessException {
+    public MissingAuthorizationCodeException() {
+        super(ErrorCode.MISSING_AUTHORIZATION_CODE);
+    }
+}

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -1,9 +1,6 @@
 package com.roome.global.config;
 
-import com.roome.domain.auth.service.CustomOAuth2UserService;
 import com.roome.global.jwt.filter.JwtAuthenticationFilter;
-import com.roome.global.jwt.handler.OAuth2FailureHandler;
-import com.roome.global.jwt.handler.OAuth2SuccessHandler;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -11,9 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
-import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -23,39 +17,19 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final CustomOAuth2UserService customOAuth2UserService;
-    private final OAuth2SuccessHandler oAuth2SuccessHandler;
-    private final OAuth2FailureHandler oAuth2FailureHandler;
-
-    @Bean
-    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
-        return new HttpSessionOAuth2AuthorizationRequestRepository();
-    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
 
                 // CSRF 보호 비활성화
-                .csrf((auth) -> auth.disable())
+                .csrf(csrf -> csrf.disable())
 
                 // 폼 로그인, HTTP 기본 인증 비활성화
                 .formLogin((form) -> form.disable())
                 .httpBasic((auth) -> auth.disable())
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                // OAuth2 로그인 설정
-                .oauth2Login(oauth2 -> oauth2
-                        .authorizationEndpoint(endpoint -> endpoint
-                                .baseUri("/api/auth/login")
-                                .authorizationRequestRepository(authorizationRequestRepository()))
-                        .redirectionEndpoint(redirection -> redirection
-                                .baseUri("/login/oauth2/code/*"))
-                        .userInfoEndpoint(userInfo -> userInfo
-                                .userService(customOAuth2UserService))
-                        .successHandler(oAuth2SuccessHandler)
-                        .failureHandler(oAuth2FailureHandler))
 
                 // 접근 제어 설정
                 .authorizeHttpRequests((auth) -> auth

--- a/roome/src/main/java/com/roome/global/exception/ErrorCode.java
+++ b/roome/src/main/java/com/roome/global/exception/ErrorCode.java
@@ -14,11 +14,12 @@ public enum ErrorCode {
   OAUTH2_AUTHENTICATION_PROCESSING(HttpStatus.UNAUTHORIZED, "소셜 로그인 처리 중 오류가 발생했습니다."),
   INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
   DISABLED_ACCOUNT(HttpStatus.FORBIDDEN, "비활성화된 계정입니다."),
+  MISSING_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "로그인 요청에는 authorization code가 필요합니다."),
 
   // JWT 관련 예외
   INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT 토큰이 유효하지 않거나, 입력값이 비어 있습니다."),
   INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."),
-  MISSING_AUTHORITY(HttpStatus.UNAUTHORIZED, "해당 토큰에는 권한 정보가 포함되어 있지 않습니다."),
+  MISSING_AUTHORITY(HttpStatus.BAD_REQUEST, "해당 토큰에는 권한 정보가 포함되어 있지 않습니다."),
 
   // User 관련 예외
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/roome/src/main/java/com/roome/global/jwt/service/TokenService.java
+++ b/roome/src/main/java/com/roome/global/jwt/service/TokenService.java
@@ -12,8 +12,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -27,12 +25,7 @@ public class TokenService {
         User user = findUserByRefreshToken(refreshToken);
         verifyRefreshTokenMatch(refreshToken, user);
 
-        // 단순히 사용자 ID만 포함
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-                user.getProviderId(),
-                null,
-                Collections.emptyList()  // 권한 없이 빈 리스트로 설정
-        );
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getId().toString(), null);
         return jwtTokenProvider.createToken(authentication);
     }
 
@@ -45,9 +38,9 @@ public class TokenService {
 
     private User findUserByRefreshToken(String refreshToken) {
         Claims claims = jwtTokenProvider.parseClaims(refreshToken);
-        String userId = claims.getSubject();
+        Long userId = Long.valueOf(claims.getSubject());
 
-        return userRepository.findByProviderId(userId)
+        return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
 

--- a/roome/src/test/java/com/roome/domain/auth/controller/AuthControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,180 @@
+package com.roome.domain.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roome.domain.auth.dto.oauth2.OAuth2Provider;
+import com.roome.domain.auth.dto.request.LoginRequest;
+import com.roome.domain.auth.dto.response.LoginResponse;
+import com.roome.domain.auth.exception.OAuth2AuthenticationProcessingException;
+import com.roome.domain.auth.service.OAuth2LoginService;
+import com.roome.global.jwt.dto.JwtToken;
+import com.roome.global.jwt.helper.TokenResponseHelper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OAuth2LoginService oAuth2LoginService;
+
+    @MockBean
+    private TokenResponseHelper tokenResponseHelper;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("카카오 로그인 요청 시 Access Token과 200을 반환한다.")
+    void testLogin_Kakao_Success() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("test-code");
+        LoginResponse mockResponse = LoginResponse.builder()
+                .accessToken("mockAccessToken")
+                .refreshToken("mockRefreshToken")
+                .expiresIn(3600L)
+                .user(LoginResponse.UserInfo.builder()
+                        .userId(1L)
+                        .nickname("testUser")
+                        .email("test@example.com")
+                        .roomId(1L)
+                        .profileImage("profile.jpg")
+                        .build())
+                .build();
+
+        when(oAuth2LoginService.login(OAuth2Provider.KAKAO, "test-code")).thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/login/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("mockAccessToken"))
+                .andExpect(jsonPath("$.refreshToken").value("mockRefreshToken"))
+                .andExpect(jsonPath("$.user.nickname").value("testUser"));
+    }
+
+    @Test
+    @DisplayName("구글 로그인 요청 시 Access Token과 200 반환한다.")
+    void testLogin_Google_Success() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("google-test-code");
+        LoginResponse mockResponse = LoginResponse.builder()
+                .accessToken("googleAccessToken")
+                .refreshToken("googleRefreshToken")
+                .expiresIn(3600L)
+                .user(LoginResponse.UserInfo.builder()
+                        .userId(2L)
+                        .nickname("googleUser")
+                        .email("google@example.com")
+                        .roomId(2L)
+                        .profileImage("google-profile.jpg")
+                        .build())
+                .build();
+
+        when(oAuth2LoginService.login(OAuth2Provider.GOOGLE, "google-test-code")).thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/login/google")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("googleAccessToken"))
+                .andExpect(jsonPath("$.refreshToken").value("googleRefreshToken"))
+                .andExpect(jsonPath("$.user.nickname").value("googleUser"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 OAuth Provider로 로그인 시 400을 응답한다.")
+    void testLogin_InvalidProvider() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("invalid-code");
+
+        when(oAuth2LoginService.login(eq(OAuth2Provider.KAKAO), any()))
+                .thenThrow(new IllegalArgumentException("Invalid OAuth Provider"));
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/login/invalidProvider")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("잘못된 인증 코드로 로그인 시 401을 응답한다.")
+    void testLogin_InvalidCode() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("wrong-code");
+
+        when(oAuth2LoginService.login(OAuth2Provider.KAKAO, "wrong-code"))
+                .thenThrow(new OAuth2AuthenticationProcessingException());
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/login/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest))
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 Access Token은 헤더에, Refresh Token은 쿠키에 존재한다.")
+    void testLogin_TokenResponseHeaders() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("test-code");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        JwtToken mockJwtToken = new JwtToken("mockAccessToken", "mockRefreshToken", "Bearer");
+
+        doNothing().when(tokenResponseHelper).setTokenResponse(any(HttpServletResponse.class), eq(mockJwtToken));
+
+        LoginResponse mockResponse = LoginResponse.builder()
+                .accessToken("mockAccessToken")
+                .refreshToken("mockRefreshToken")
+                .expiresIn(3600L)
+                .user(LoginResponse.UserInfo.builder()
+                        .userId(1L)
+                        .nickname("testUser")
+                        .email("test@example.com")
+                        .roomId(1L)
+                        .profileImage("profile.jpg")
+                        .build())
+                .build();
+
+        when(oAuth2LoginService.login(OAuth2Provider.KAKAO, "test-code")).thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/login/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("mockAccessToken"))
+                .andExpect(jsonPath("$.refreshToken").value("mockRefreshToken"));
+
+        // Verify JWT Token 설정이 정상적으로 호출되었는지 확인
+        verify(tokenResponseHelper, times(1)).setTokenResponse(any(HttpServletResponse.class), eq(mockJwtToken));
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)
AuthController 테스트 추가

### ✅ PR 설명
- OAuth2ClientProperties 및 SecurityConfig를 정리하여 코드 가독성을 개선
- JWT 토큰 재발급 시 providerId 대신 userId를 사용하여 사용자 조회 로직 변경
- AuthControllerTest에서 로그인 요청 관련 테스트를 추가하고 예외 처리를 개선

### 🏗 작업 내용
- [ ] OAuth2ClientProperties 설정을 정리하여 OAuth2 프로바이더별 설정을 명확하게 관리
- [ ] JWT 토큰 재발급 시 providerId가 아닌 userId를 JWT subject로 설정하여 정확한 사용자 조회 가능하도록 변경
- [ ] AuthControllerTest에서 로그인 요청 관련 테스트 추가 및 예외 처리 개선

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
