### PR TITLE
Refactor: JWT 및 OAuth2 인증 로직 개선 및 테스트 추가

### DIFF
--- a/roome/build.gradle
+++ b/roome/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.junit.jupiter:junit-jupiter'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
+	testImplementation 'org.mockito:mockito-core'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/roome/src/main/java/com/roome/domain/auth/dto/oauth2/GoogleResponse.java
+++ b/roome/src/main/java/com/roome/domain/auth/dto/oauth2/GoogleResponse.java
@@ -29,4 +29,9 @@ public class GoogleResponse implements OAuth2Response {
     public String getProfileImageUrl() {
         return attributes.get("picture").toString();
     }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
 }

--- a/roome/src/main/java/com/roome/domain/auth/dto/oauth2/KakaoResponse.java
+++ b/roome/src/main/java/com/roome/domain/auth/dto/oauth2/KakaoResponse.java
@@ -49,4 +49,12 @@ public class KakaoResponse implements OAuth2Response {
         Object profileImage = profile.get("profile_image_url");
         return profileImage != null ? profileImage.toString() : null;
     }
+
+    @Override
+    public String getEmail() {
+        if (kakaoAccount != null && kakaoAccount.containsKey("email")) {
+            return kakaoAccount.get("email").toString();
+        }
+        return null;
+    }
 }

--- a/roome/src/main/java/com/roome/domain/auth/dto/oauth2/NaverResponse.java
+++ b/roome/src/main/java/com/roome/domain/auth/dto/oauth2/NaverResponse.java
@@ -29,4 +29,9 @@ public class NaverResponse implements OAuth2Response {
     public String getProfileImageUrl() {
         return attributes.get("profile_image").toString();
     }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
 }

--- a/roome/src/main/java/com/roome/domain/auth/dto/oauth2/OAuth2Provider.java
+++ b/roome/src/main/java/com/roome/domain/auth/dto/oauth2/OAuth2Provider.java
@@ -3,7 +3,6 @@ package com.roome.domain.auth.dto.oauth2;
 import com.roome.domain.auth.exception.InvalidProviderException;
 import com.roome.domain.auth.service.OAuth2Factory;
 import lombok.Getter;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Map;
 
@@ -16,10 +15,6 @@ public enum OAuth2Provider {
     private final String registrationId;
     private final String tokenUri;
     private final String userInfoUri;
-
-    @Value("${oauth2.google.client-id}") private String googleClientId;
-    @Value("${oauth2.google.client-secret}") private String googleClientSecret;
-    @Value("${oauth2.google.redirect-uri}") private String googleRedirectUri;
 
     OAuth2Provider(String registrationId, String tokenUri, String userInfoUri) {
         this.registrationId = registrationId;

--- a/roome/src/main/java/com/roome/domain/auth/dto/oauth2/OAuth2Response.java
+++ b/roome/src/main/java/com/roome/domain/auth/dto/oauth2/OAuth2Response.java
@@ -6,5 +6,5 @@ public interface OAuth2Response {
     String getProviderId();
     String getName();
     String getProfileImageUrl();
-
+    String getEmail();
 }

--- a/roome/src/main/java/com/roome/domain/auth/security/OAuth2UserPrincipal.java
+++ b/roome/src/main/java/com/roome/domain/auth/security/OAuth2UserPrincipal.java
@@ -25,8 +25,12 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
 
     @Override
     public Map<String, Object> getAttributes() {
-        return attributes;
+        return Map.of(
+                "user", oAuth2Response,
+                "email", user.getEmail()
+        );
     }
+
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -36,6 +40,10 @@ public class OAuth2UserPrincipal implements OAuth2User, UserDetails {
     @Override
     public String getName() {
         return user.getName();
+    }
+
+    public String getEmail() {
+        return user.getEmail();
     }
 
     @Override

--- a/roome/src/main/java/com/roome/domain/auth/service/OAuth2Factory.java
+++ b/roome/src/main/java/com/roome/domain/auth/service/OAuth2Factory.java
@@ -6,7 +6,6 @@ import com.roome.domain.auth.exception.InvalidProviderException;
 import java.util.Map;
 
 public class OAuth2Factory {
-
     public static OAuth2Response getProvider(String registrationId, Map<String, Object> attributes) {
         if (OAuth2Provider.GOOGLE.getRegistrationId().equals(registrationId)) {
             return new GoogleResponse(attributes);
@@ -14,9 +13,8 @@ public class OAuth2Factory {
             return new NaverResponse(attributes);
         } else if (OAuth2Provider.KAKAO.getRegistrationId().equals(registrationId)) {
             return new KakaoResponse(attributes);
-        } else {
-            throw new InvalidProviderException();
         }
+        throw new InvalidProviderException();
     }
 }
 

--- a/roome/src/main/java/com/roome/domain/auth/service/OAuth2LoginService.java
+++ b/roome/src/main/java/com/roome/domain/auth/service/OAuth2LoginService.java
@@ -50,7 +50,7 @@ public class OAuth2LoginService {
         }
 
         // Authentication 객체 생성 후 JWT 발급
-        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getProviderId(), null);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getId().toString(), null);
         JwtToken jwtToken = jwtTokenProvider.createToken(authentication);
 
         return LoginResponse.builder()

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -17,7 +17,7 @@ public class User extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(/*nullable = false, */length = 255, unique = true)
+    @Column(nullable = false, length = 255, unique = true)
     private String email;
 
     // 소셜에서 가져온 실제 이름

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package com.roome.global.config;
 
+import com.roome.domain.auth.service.CustomOAuth2UserService;
 import com.roome.global.jwt.filter.JwtAuthenticationFilter;
+import com.roome.global.jwt.handler.OAuth2FailureHandler;
+import com.roome.global.jwt.handler.OAuth2SuccessHandler;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +11,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -17,19 +23,39 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+
+    @Bean
+    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+        return new HttpSessionOAuth2AuthorizationRequestRepository();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
 
                 // CSRF 보호 비활성화
-                .csrf(csrf -> csrf.disable())
+                .csrf((auth) -> auth.disable())
 
                 // 폼 로그인, HTTP 기본 인증 비활성화
                 .formLogin((form) -> form.disable())
                 .httpBasic((auth) -> auth.disable())
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .baseUri("/api/auth/login")
+                                .authorizationRequestRepository(authorizationRequestRepository()))
+                        .redirectionEndpoint(redirection -> redirection
+                                .baseUri("/login/oauth2/code/*"))
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler))
 
                 // 접근 제어 설정
                 .authorizeHttpRequests((auth) -> auth
@@ -38,11 +64,7 @@ public class SecurityConfig {
                                 "/login/oauth2/code/*",
                                 "/oauth2/authorization/*",
                                 "/api/auth/**",
-                                "/error",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/api/**"
+                                "/error"
                         ).permitAll()
                         .anyRequest().authenticated());
 

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 // OAuth2 로그인 설정
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(endpoint -> endpoint
-                                .baseUri("/api/auth/login")
+                                .baseUri("/oauth2/authorization")
                                 .authorizationRequestRepository(authorizationRequestRepository()))
                         .redirectionEndpoint(redirection -> redirection
                                 .baseUri("/login/oauth2/code/*"))

--- a/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
+++ b/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-//@RestControllerAdvice
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
   // 비즈니스 관련 예러 처리

--- a/roome/src/main/java/com/roome/global/jwt/handler/OAuth2SuccessHandler.java
+++ b/roome/src/main/java/com/roome/global/jwt/handler/OAuth2SuccessHandler.java
@@ -30,6 +30,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         OAuth2UserPrincipal oauth2User = (OAuth2UserPrincipal) authentication.getPrincipal();
 
+        String email = oauth2User.getAttribute("email");
+
         // JWT 토큰 생성
         JwtToken token = jwtTokenProvider.createToken(authentication);
 
@@ -40,6 +42,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .expiresIn(3600L)
                 .user(LoginResponse.UserInfo.builder()
                         .userId(oauth2User.getUser().getId())
+                        .email(email)
                         .nickname(oauth2User.getUser().getNickname())
                         .email(oauth2User.getUser().getEmail())
                         .profileImage(oauth2User.getUser().getProfileImage())

--- a/roome/src/main/java/com/roome/global/jwt/service/TokenService.java
+++ b/roome/src/main/java/com/roome/global/jwt/service/TokenService.java
@@ -23,7 +23,6 @@ public class TokenService {
     public JwtToken reissueToken(String refreshToken) {
         validateRefreshToken(refreshToken);
         User user = findUserByRefreshToken(refreshToken);
-        verifyRefreshTokenMatch(refreshToken, user);
 
         Authentication authentication = new UsernamePasswordAuthenticationToken(user.getId().toString(), null);
         return jwtTokenProvider.createToken(authentication);
@@ -42,11 +41,5 @@ public class TokenService {
 
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-    }
-
-    private void verifyRefreshTokenMatch(String refreshToken, User user) {
-        if (!refreshToken.equals(user.getRefreshToken())) {
-            throw new InvalidRefreshTokenException();
-        }
     }
 }

--- a/roome/src/main/java/com/roome/global/jwt/service/TokenService.java
+++ b/roome/src/main/java/com/roome/global/jwt/service/TokenService.java
@@ -12,6 +12,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -24,7 +26,10 @@ public class TokenService {
         validateRefreshToken(refreshToken);
         User user = findUserByRefreshToken(refreshToken);
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getId().toString(), null);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                user.getId().toString(), null, Collections.emptyList()
+        );
+
         return jwtTokenProvider.createToken(authentication);
     }
 

--- a/roome/src/main/resources/application.yml
+++ b/roome/src/main/resources/application.yml
@@ -14,8 +14,8 @@ spring:
             redirect-uri: http://localhost:8080/login/oauth2/code/google
             authorization-grant-type: authorization_code
             scope:
-              - profile
               - email
+              - profile
           naver:
             client-name: naver
             client-id: ${NAVER_CLIENT_ID}
@@ -24,16 +24,18 @@ spring:
             authorization-grant-type: authorization_code
             scope:
               - name
+              - email
               - profile_image
           kakao:
             client-name: Kakao
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:
               - profile_nickname
+              - account_email
               - profile_image
         provider:
           naver:
@@ -74,9 +76,9 @@ spring:
         dialect: org.hibernate.dialect.MariaDBDialect
   data:
     redis:
-      port: ${redis.port}
-      host: ${redis.host}
-      password: ${redis.password}
+      port: ${REDIS_PORT}
+      host: ${REDIS_HOST}
+      password: ${REDIS_PASSWORD}
 
 ---
 ---

--- a/roome/src/test/java/com/roome/domain/auth/service/OAuth2LoginServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/auth/service/OAuth2LoginServiceTest.java
@@ -1,0 +1,212 @@
+package com.roome.domain.auth.service;
+
+import com.roome.domain.auth.dto.oauth2.OAuth2Provider;
+import com.roome.domain.auth.dto.response.LoginResponse;
+import com.roome.domain.auth.exception.OAuth2AuthenticationProcessingException;
+import com.roome.domain.room.dto.RoomResponseDto;
+import com.roome.domain.room.service.RoomService;
+import com.roome.domain.user.entity.Provider;
+import com.roome.domain.user.entity.Status;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import com.roome.global.jwt.dto.JwtToken;
+import com.roome.global.jwt.service.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2LoginServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private RoomService roomService;
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private OAuth2ClientProperties oauth2ClientProperties;
+
+    @InjectMocks
+    private OAuth2LoginService oauth2LoginService;
+
+    private static final String TEST_AUTH_CODE = "test_auth_code";
+    private static final String TEST_ACCESS_TOKEN = "test_access_token";
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_NAME = "Test User";
+    private static final String TEST_PROFILE_IMAGE = "test_image_url";
+    private static final String TEST_PROVIDER_ID = "test_provider_id";
+
+    @BeforeEach
+    void setUp() {
+        OAuth2ClientProperties.Registration registration = mock(OAuth2ClientProperties.Registration.class);
+        Map<String, OAuth2ClientProperties.Registration> registrations = Map.of(
+                "kakao", registration
+        );
+
+        given(oauth2ClientProperties.getRegistration())
+                .willReturn(registrations);
+        given(registration.getClientId())
+                .willReturn("test-client-id");
+        given(registration.getClientSecret())
+                .willReturn("test-client-secret");
+        given(registration.getRedirectUri())
+                .willReturn("test-redirect-uri");
+    }
+
+    @Test
+    @DisplayName("로그인 성공 - 신규 사용자")
+    void loginSuccess_NewUser() {
+        // given
+        User newUser = createUser(1L);
+        JwtToken jwtToken = createJwtToken();
+        RoomResponseDto roomResponseDto = RoomResponseDto.builder()
+                .roomId(1L)
+                .userId(1L)
+                .theme("Default Theme")
+                .createdAt(LocalDateTime.now())
+                .furnitures(Collections.emptyList())
+                .build();
+
+        mockTokenResponse();
+        mockUserProfileResponse();
+
+        given(userRepository.findByProviderId(anyString()))
+                .willReturn(Optional.empty());
+        given(userRepository.save(any(User.class)))
+                .willReturn(newUser);
+        given(jwtTokenProvider.createToken(any(Authentication.class)))
+                .willReturn(jwtToken);
+        given(roomService.getRoomByUserId(newUser.getId()))
+                .willReturn(roomResponseDto);
+
+        // when
+        LoginResponse response = oauth2LoginService.login(OAuth2Provider.KAKAO, TEST_AUTH_CODE);
+
+        // then
+        assertNotNull(response);
+        assertEquals(jwtToken.getAccessToken(), response.getAccessToken());
+        assertEquals(jwtToken.getRefreshToken(), response.getRefreshToken());
+        assertEquals(newUser.getId(), response.getUser().getUserId());
+        verify(userRepository).save(any(User.class));
+        verify(roomService).createRoom(newUser.getId());
+    }
+
+    @Test
+    @DisplayName("로그인 성공 - 기존 사용자")
+    void loginSuccess_ExistingUser() {
+        // given
+        User existingUser = createUser(1L);
+        existingUser.updateLastLogin();
+        JwtToken jwtToken = createJwtToken();
+        RoomResponseDto roomResponseDto = RoomResponseDto.builder()
+                .roomId(1L)
+                .userId(1L)
+                .theme("Default Theme")
+                .createdAt(LocalDateTime.now())
+                .furnitures(Collections.emptyList())
+                .build();
+
+        mockTokenResponse();
+        mockUserProfileResponse();
+
+        given(userRepository.findByProviderId(anyString()))
+                .willReturn(Optional.of(existingUser));
+        given(jwtTokenProvider.createToken(any(Authentication.class)))
+                .willReturn(jwtToken);
+        given(roomService.getRoomByUserId(existingUser.getId()))
+                .willReturn(roomResponseDto);
+
+        // when
+        LoginResponse response = oauth2LoginService.login(OAuth2Provider.KAKAO, TEST_AUTH_CODE);
+
+        // then
+        assertNotNull(response);
+        assertEquals(jwtToken.getAccessToken(), response.getAccessToken());
+        assertEquals(jwtToken.getRefreshToken(), response.getRefreshToken());
+        assertEquals(existingUser.getId(), response.getUser().getUserId());
+        verify(userRepository, never()).save(any(User.class));
+        verify(roomService, never()).createRoom(anyLong());
+    }
+
+    @Test
+    @DisplayName("OAuth2 인증 실패 시 예외가 발생한다")
+    void loginFail_OAuth2AuthenticationFailed() {
+        // given
+        given(restTemplate.postForObject(
+                anyString(),
+                any(Map.class),
+                eq(Map.class)))
+                .willThrow(new RestClientException("Invalid auth code"));
+
+        // when & then
+        assertThrows(OAuth2AuthenticationProcessingException.class, () ->
+                oauth2LoginService.login(OAuth2Provider.KAKAO, TEST_AUTH_CODE)
+        );
+    }
+
+    private void mockTokenResponse() {
+        Map<String, Object> tokenResponse = Map.of("access_token", TEST_ACCESS_TOKEN);
+        given(restTemplate.postForObject(
+                anyString(),
+                any(Map.class),
+                eq(Map.class)))
+                .willReturn(tokenResponse);
+    }
+
+    private void mockUserProfileResponse() {
+        Map<String, Object> mockUserInfo = Map.of(
+                "id", TEST_PROVIDER_ID,
+                "kakao_account", Map.of(
+                        "email", TEST_EMAIL,
+                        "profile", Map.of(
+                                "nickname", TEST_NAME,
+                                "profile_image_url", TEST_PROFILE_IMAGE
+                        )
+                )
+        );
+        given(restTemplate.getForObject(anyString(), eq(Map.class)))
+                .willReturn(mockUserInfo);
+    }
+
+    private User createUser(Long id) {
+        return User.builder()
+                .id(id)
+                .name(TEST_NAME)
+                .nickname(TEST_NAME)
+                .email(TEST_EMAIL)
+                .profileImage(TEST_PROFILE_IMAGE)
+                .provider(Provider.KAKAO)
+                .providerId(TEST_PROVIDER_ID)
+                .status(Status.OFFLINE)
+                .build();
+    }
+
+    private JwtToken createJwtToken() {
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(TEST_ACCESS_TOKEN)
+                .refreshToken("test_refresh_token")
+                .build();
+    }
+}

--- a/roome/src/test/java/com/roome/global/jwt/service/JwtTokenProviderTest.java
+++ b/roome/src/test/java/com/roome/global/jwt/service/JwtTokenProviderTest.java
@@ -1,0 +1,127 @@
+package com.roome.global.jwt.service;
+
+import com.roome.domain.auth.security.OAuth2UserPrincipal;
+import com.roome.domain.auth.dto.oauth2.OAuth2Response;
+import com.roome.domain.auth.dto.oauth2.OAuth2Provider;
+import com.roome.domain.user.entity.User;
+import com.roome.global.jwt.dto.JwtToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+
+    @InjectMocks
+    private JwtTokenProvider jwtTokenProvider;
+
+    private String secret;
+    private SecretKey secretKey;
+    private String testEmail;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        secret = "testsecretkeytestsecretkeytestsecretkeytestsecretkey";
+        secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        jwtTokenProvider.setSecretKey(secretKey);
+        testEmail = "test@example.com";
+
+        token = Jwts.builder()
+                .setSubject("userId")
+                .claim("email", testEmail)
+                .setExpiration(new Date(System.currentTimeMillis() + 3600000))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    @Test
+    @DisplayName("JWT 토큰에서 이메일을 추출한다")
+    void testGetEmailFromToken() {
+        String extractedEmail = jwtTokenProvider.getEmailFromToken(token);
+        assertThat(extractedEmail).isEqualTo(testEmail);
+    }
+
+    @Test
+    @DisplayName("유효한 JWT 토큰을 검증한다")
+    void testValidateToken() {
+        boolean isValid = jwtTokenProvider.validateToken(token);
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("JWT 토큰에 이메일 클레임이 포함되는지 검증")
+    void testCreateTokenWithEmailClaim() {
+        // given
+        Map<String, Object> attributes = Map.of(
+                "id", "test_id",
+                "kakao_account", Map.of(
+                        "email", testEmail,
+                        "profile", Map.of(
+                                "nickname", "Test User",
+                                "profile_image_url", "test_profile.jpg"
+                        )
+                )
+        );
+
+        User user = User.builder()
+                .id(1L)
+                .email(testEmail)
+                .build();
+
+        OAuth2Response oAuth2Response = OAuth2Provider.KAKAO.createOAuth2Response(attributes);
+        OAuth2UserPrincipal userPrincipal = new OAuth2UserPrincipal(user, oAuth2Response);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                userPrincipal, null, userPrincipal.getAuthorities()
+        );
+
+        // when
+        JwtToken token = jwtTokenProvider.createToken(authentication);
+
+        // then
+        Claims claims = jwtTokenProvider.parseClaims(token.getAccessToken());
+        assertThat(claims.get("email", String.class)).isEqualTo(testEmail);
+    }
+
+    @Test
+    @DisplayName("OAuth2UserPrincipal에서 이메일 추출")
+    void testGetEmailFromOAuth2UserPrincipal() {
+        Map<String, Object> attributes = Map.of(
+                "id", "test_id",
+                "kakao_account", Map.of(
+                        "email", testEmail,
+                        "profile", Map.of(
+                                "nickname", "Test User",
+                                "profile_image_url", "test_profile.jpg"
+                        )
+                )
+        );
+
+        User user = User.builder()
+                .id(1L)
+                .email(testEmail)
+                .build();
+
+        OAuth2Response oAuth2Response = OAuth2Provider.KAKAO.createOAuth2Response(attributes);
+        OAuth2UserPrincipal userPrincipal = new OAuth2UserPrincipal(user, oAuth2Response);
+
+        String email = userPrincipal.getEmail();
+        assertThat(email).isEqualTo(testEmail);
+    }
+}

--- a/roome/src/test/java/com/roome/global/jwt/service/TokenServiceTest.java
+++ b/roome/src/test/java/com/roome/global/jwt/service/TokenServiceTest.java
@@ -1,0 +1,133 @@
+package com.roome.global.jwt.service;
+
+import com.roome.domain.user.entity.Provider;
+import com.roome.domain.user.entity.Status;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import com.roome.global.jwt.dto.JwtToken;
+import com.roome.global.jwt.exception.InvalidRefreshTokenException;
+import com.roome.global.jwt.exception.UserNotFoundException;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Test
+    @DisplayName("토큰 재발급 성공")
+    void reissueTokenSuccess() {
+        // given
+        String refreshToken = "valid_refresh_token";
+        Claims claims = mock(Claims.class);
+        User user = createUser(1L);
+        JwtToken newToken = createJwtToken();
+
+        given(jwtTokenProvider.validateToken(refreshToken))
+                .willReturn(true);
+
+        given(jwtTokenProvider.parseClaims(refreshToken))
+                .willReturn(claims);
+
+        given(claims.getSubject())
+                .willReturn("1"); // userId
+
+        given(userRepository.findById(1L))
+                .willReturn(Optional.of(user));
+
+        given(jwtTokenProvider.createToken(any(Authentication.class)))
+                .willReturn(newToken);
+
+        // when
+        JwtToken result = tokenService.reissueToken(refreshToken);
+
+        // then
+        assertNotNull(result);
+        assertEquals(newToken.getAccessToken(), result.getAccessToken());
+        assertEquals(newToken.getRefreshToken(), result.getRefreshToken());
+        verify(jwtTokenProvider).validateToken(refreshToken);
+        verify(userRepository).findById(1L);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰으로 재발급 시도 시 예외가 발생한다.")
+    void reissueTokenFail_InvalidRefreshToken() {
+        // given
+        String invalidRefreshToken = "invalid_refresh_token";
+
+        given(jwtTokenProvider.validateToken(invalidRefreshToken))
+                .willReturn(false);
+
+        // when & then
+        assertThrows(InvalidRefreshTokenException.class, () ->
+                tokenService.reissueToken(invalidRefreshToken));
+
+        verify(jwtTokenProvider).validateToken(invalidRefreshToken);
+        verify(jwtTokenProvider, never()).parseClaims(any());
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자의 리프레시 토큰으로 재발급 시도 시 예외가 발생한다.")
+    void reissueTokenFail_UserNotFound() {
+        // given
+        String refreshToken = "valid_refresh_token";
+        Claims claims = mock(Claims.class);
+
+        given(jwtTokenProvider.validateToken(refreshToken))
+                .willReturn(true);
+
+        given(jwtTokenProvider.parseClaims(refreshToken))
+                .willReturn(claims);
+
+        given(claims.getSubject())
+                .willReturn("999"); // 존재하지 않는 userId
+
+        given(userRepository.findById(999L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(UserNotFoundException.class, () ->
+                tokenService.reissueToken(refreshToken)
+        );
+    }
+
+    private User createUser(Long id) {
+        return User.builder()
+                .id(id)
+                .name("Test User")
+                .nickname("Tester")
+                .provider(Provider.KAKAO)
+                .providerId("test_provider_id")
+                .status(Status.OFFLINE)
+                .build();
+    }
+
+    private JwtToken createJwtToken() {
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken("new_access_token")
+                .refreshToken("new_refresh_token")
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 JWT 및 OAuth2 인증 로직 개선 및 테스트 추가

### ✅ PR 설명
JWT 및 OAuth2 인증 로직을 개선하고, 관련 테스트를 추가하였습니다.

### 🏗 작업 내용
- [x] 인증 토큰의 subject를 providerId에서 userId로 변경하여 일관성 유지
- [x] JWT 토큰에 email 정보를 포함하여 OAuth2 인증 응답 개선
- [x] WT 및 OAuth2 인증 관련 서비스 테스트 추가

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
