### PR TITLE
Fix: 실제 사용자가 저장한 도서와 음악 개수, 작성한 서평과 음악 리뷰 개수가 반영되도록 수정

### DIFF
--- a/roome/src/main/java/com/roome/domain/cdcomment/repository/CdCommentRepository.java
+++ b/roome/src/main/java/com/roome/domain/cdcomment/repository/CdCommentRepository.java
@@ -1,0 +1,9 @@
+package com.roome.domain.cdcomment.repository;
+
+import com.roome.domain.cdcomment.entity.CdComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CdCommentRepository extends JpaRepository<CdComment, Long> {
+
+    Long countByUserId(Long userId);
+}

--- a/roome/src/main/java/com/roome/domain/mybookreview/entity/repository/MyBookReviewRepository.java
+++ b/roome/src/main/java/com/roome/domain/mybookreview/entity/repository/MyBookReviewRepository.java
@@ -14,4 +14,6 @@ public interface MyBookReviewRepository extends JpaRepository<MyBookReview, Long
     }
 
     Optional<MyBookReview> findByMyBookId(Long myBookId);
+
+    Long countByUserId(Long userId);
 }

--- a/roome/src/main/java/com/roome/domain/room/dto/RoomResponseDto.java
+++ b/roome/src/main/java/com/roome/domain/room/dto/RoomResponseDto.java
@@ -22,7 +22,7 @@ public class RoomResponseDto {
     private StorageLimitsDto storageLimits;
     private UserStorageDto userStorage;
 
-    public static RoomResponseDto from(Room room, int savedMusic, int savedBooks, int writtenReviews, int writtenMusicLogs) {
+    public static RoomResponseDto from(Room room, Long savedMusic, Long savedBooks, Long writtenReviews, Long writtenMusicLogs) {
         return RoomResponseDto.builder()
                 .roomId(room.getId())
                 .userId(room.getUser().getId())

--- a/roome/src/main/java/com/roome/domain/room/dto/UserStorageDto.java
+++ b/roome/src/main/java/com/roome/domain/room/dto/UserStorageDto.java
@@ -9,12 +9,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserStorageDto {
 
-    private int savedMusic;
-    private int savedBooks;
-    private int writtenReviews;
-    private int writtenMusicLogs;
+    private Long savedMusic;
+    private Long savedBooks;
+    private Long writtenReviews;
+    private Long writtenMusicLogs;
 
-    public static UserStorageDto from(int savedMusic, int savedBooks, int writtenReviews, int writtenMusicLogs) {
+    public static UserStorageDto from(Long savedMusic, Long savedBooks, Long writtenReviews, Long writtenMusicLogs) {
         return UserStorageDto.builder()
                 .savedMusic(savedMusic)
                 .savedBooks(savedBooks)

--- a/roome/src/main/java/com/roome/domain/room/service/RoomService.java
+++ b/roome/src/main/java/com/roome/domain/room/service/RoomService.java
@@ -1,8 +1,14 @@
 package com.roome.domain.room.service;
 
+import com.roome.domain.cdcomment.repository.CdCommentRepository;
+import com.roome.domain.mybook.entity.MyBookCount;
+import com.roome.domain.mybook.entity.repository.MyBookCountRepository;
+import com.roome.domain.mybookreview.entity.repository.MyBookReviewRepository;
+import com.roome.domain.mycd.repository.MyCdCountRepository;
 import com.roome.domain.room.dto.RoomResponseDto;
 import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.entity.RoomTheme;
+import com.roome.domain.mycd.entity.MyCdCount;
 import com.roome.domain.room.repository.RoomRepository;
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
@@ -18,6 +24,10 @@ public class RoomService {
 
     private final RoomRepository roomRepository;
     private final UserRepository userRepository;
+    private final MyCdCountRepository myCdCountRepository;
+    private final MyBookCountRepository myBookCountRepository;
+    private final MyBookReviewRepository myBookReviewRepository;
+    private final CdCommentRepository cdCommentRepository;
 
     @Transactional
     public RoomResponseDto createRoom(Long userId){
@@ -31,10 +41,10 @@ public class RoomService {
 
         Room savedRoom = roomRepository.save(newRoom);
 
-        int savedMusic = 0;
-        int savedBooks = 0;
-        int writtenReviews = 0;
-        int writtenMusicLogs = 0;
+        Long savedMusic = 0L;
+        Long savedBooks = 0L;
+        Long writtenReviews = 0L;
+        Long writtenMusicLogs = 0L;
 
         return RoomResponseDto.from(savedRoom, savedMusic, savedBooks, writtenReviews, writtenMusicLogs);
     }
@@ -44,10 +54,10 @@ public class RoomService {
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
 
-        int savedMusic = fetchSavedMusicCount(room.getUser().getId());
-        int savedBooks = fetchSavedBooksCount(room.getUser().getId());
-        int writtenReviews = fetchWrittenReviewsCount(room.getUser().getId());
-        int writtenMusicLogs = fetchWrittenMusicLogsCount(room.getUser().getId());
+        Long savedMusic = fetchSavedMusicCount(room);
+        Long savedBooks = fetchSavedBooksCount(roomId);
+        Long writtenReviews = fetchWrittenReviewsCount(room.getUser().getId());
+        Long writtenMusicLogs = fetchWrittenMusicLogsCount(room.getUser().getId());
 
         return RoomResponseDto.from(room, savedMusic, savedBooks, writtenReviews, writtenMusicLogs);
     }
@@ -57,10 +67,10 @@ public class RoomService {
         Room room = roomRepository.findByUserId(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
 
-        int savedMusic = fetchSavedMusicCount(userId);
-        int savedBooks = fetchSavedBooksCount(userId);
-        int writtenReviews = fetchWrittenReviewsCount(userId);
-        int writtenMusicLogs = fetchWrittenMusicLogsCount(userId);
+        Long savedMusic = fetchSavedMusicCount(room);
+        Long savedBooks = fetchSavedBooksCount(room.getId());
+        Long writtenReviews = fetchWrittenReviewsCount(userId);
+        Long writtenMusicLogs = fetchWrittenMusicLogsCount(userId);
 
         return RoomResponseDto.from(room, savedMusic, savedBooks, writtenReviews, writtenMusicLogs);
 
@@ -81,19 +91,23 @@ public class RoomService {
         return theme.name();
     }
 
-    private int fetchSavedMusicCount(Long userId) {
-        return 0;
+    private Long fetchSavedMusicCount(Room room) {
+        return myCdCountRepository.findByRoom(room)
+                .map(MyCdCount::getCount)
+                .orElse(0L);
     }
 
-    private int fetchSavedBooksCount(Long userId) {
-        return 0;
+    private Long fetchSavedBooksCount(Long roomId) {
+        return myBookCountRepository.findByRoomId(roomId)
+                .map(MyBookCount::getCount)
+                .orElse(0L);
     }
 
-    private int fetchWrittenReviewsCount(Long userId) {
-        return 0;
+    private Long fetchWrittenReviewsCount(Long userId) {
+        return myBookReviewRepository.countByUserId(userId);
     }
 
-    private int fetchWrittenMusicLogsCount(Long userId) {
-        return 0;
+    private Long fetchWrittenMusicLogsCount(Long userId) {
+        return cdCommentRepository.countByUserId(userId);
     }
 }


### PR DESCRIPTION
### ✅ PR 설명
실제 사용자가 저장한 도서와 음악 개수, 작성한 서평과 음악 리뷰 개수가 반영되도록 수정했습니다.

### 🏗 작업 내용
- [ ] 실제 사용자가 저장한 도서 개수 반영
- [ ] 실제 사용자가 저장한 음악 개수 반영
- [ ] 실제 사용자가 작성한 서평 개수 반영
- [ ] 실제 사용자가 작성한 음악 리뷰 개수 반영

### 🚨 참고 사항 (선택)
> MyBookReview와 CdComment 부분에 countByUserId 추가했습니다!