### PR TITLE
Refactor: mycd, cdcomment, cdtemplate 케밥 케이스 적용

### DIFF
--- a/roome/src/main/java/com/roome/domain/cdcomment/controller/CdCommentController.java
+++ b/roome/src/main/java/com/roome/domain/cdcomment/controller/CdCommentController.java
@@ -16,7 +16,7 @@ public class CdCommentController {
 
   private final CdCommentService cdCommentService;
 
-  @PostMapping("/api/mycd/{myCdId}/comment")
+  @PostMapping("/api/my-cd/{myCdId}/comment")
   public ResponseEntity<CdCommentResponse> create(
       @PathVariable Long myCdId,
       @RequestBody @Valid CdCommentCreateRequest request
@@ -26,7 +26,7 @@ public class CdCommentController {
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping("/api/mycd/{myCdId}/comments")
+  @GetMapping("/api/my-cd/{myCdId}/comments")
   public ResponseEntity<CdCommentListResponse> getComments(
       @PathVariable Long myCdId,
       @RequestParam(value = "page", required = false, defaultValue = "0") int page,
@@ -36,7 +36,7 @@ public class CdCommentController {
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping("/api/mycd/{myCdId}/comments/search")
+  @GetMapping("/api/my-cd/{myCdId}/comments/search")
   public ResponseEntity<CdCommentListResponse> searchComments(
       @PathVariable Long myCdId,
       @RequestParam("query") String keyword,
@@ -47,13 +47,13 @@ public class CdCommentController {
     return ResponseEntity.ok(response);
   }
 
-  @DeleteMapping("/api/mycd/comments/{commentId}")
+  @DeleteMapping("/api/my-cd/comments/{commentId}")
   public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
     cdCommentService.deleteComment(commentId);
     return ResponseEntity.noContent().build();
   }
 
-  @DeleteMapping("/api/mycd/comments")
+  @DeleteMapping("/api/my-cd/comments")
   public ResponseEntity<Void> deleteMultipleComments(@RequestParam List<Long> commentIds) {
     cdCommentService.deleteMultipleComments(commentIds);
     return ResponseEntity.noContent().build();

--- a/roome/src/main/java/com/roome/domain/cdcomment/controller/MockCdCommentController.java
+++ b/roome/src/main/java/com/roome/domain/cdcomment/controller/MockCdCommentController.java
@@ -15,7 +15,7 @@ import java.util.Random;
 
 @Tag(name = "Mock - CdComment", description = "댓글 등록/조회/검색/삭제")
 @RestController
-@RequestMapping("/mock/mycd")
+@RequestMapping("/mock/my-cd")
 public class MockCdCommentController {
 
   @Operation(summary = "Mock - CD 댓글 작성", description = "CD에 댓글을 작성합니다.")

--- a/roome/src/main/java/com/roome/domain/cdtemplate/controller/CdTemplateController.java
+++ b/roome/src/main/java/com/roome/domain/cdtemplate/controller/CdTemplateController.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/mycd/{myCdId}/template")
+@RequestMapping("/api/my-cd/{myCdId}/template")
 @RequiredArgsConstructor
 public class CdTemplateController {
 

--- a/roome/src/main/java/com/roome/domain/cdtemplate/controller/MockCdTemplateController.java
+++ b/roome/src/main/java/com/roome/domain/cdtemplate/controller/MockCdTemplateController.java
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 @Tag(name = "Mock - CD Template", description = "CD 템플릿 작성/조회/수정/삭제")
 @RestController
-@RequestMapping("/mock/api/mycd/{myCdId}/template")
+@RequestMapping("/mock/api/my-cd/{myCdId}/template")
 public class MockCdTemplateController {
 
   private final AtomicLong templateIdCounter = new AtomicLong(1);

--- a/roome/src/main/java/com/roome/domain/mycd/controller/MockMyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MockMyCdController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Tag(name = "Mock - MyCd", description = "CD 등록/조회/삭제")
 @RestController
-@RequestMapping("/mock/mycd")
+@RequestMapping("/mock/my-cd")
 public class MockMyCdController {
 
   @Operation(summary = "Mock - CD 추가", description = "사용자의 MyCd 목록에 CD를 추가")

--- a/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/mycd")
+@RequestMapping("/api/my-cd")
 @RequiredArgsConstructor
 public class MyCdController {
 


### PR DESCRIPTION
## 📌 PR 제목 Refactor: API 경로를 케밥 케이스로 변경

### ✅ PR 설명
MyCd, CdComment, CdTemplate 도메인의 API 경로를 기존 카멜 케이스(Camel Case) → **케밥 케이스(Kebab Case)**로 변경하였습니다.

### 🏗 작업 내용
- [ ] MyCd 도메인의 API 경로 변경 (/api/mycd → /api/my-cd)
- [ ] CdComment 도메인의 API 경로 변경 (/api/cdcomment → /api/cd-comment)
- [ ] CdTemplate 도메인의 API 경로 변경 (/api/cdtemplate → /api/cd-template)
 
### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> #126 

### 🚨 참고 사항 (선택)
> 패키지명(com.roome.domain.mycd)은 유지하고, API 엔드포인트(URL)만 케밥 케이스로 변경했습니다.
