### PR TITLE
Refactor: mycd, cdcomment, cdtemplate 테스트 코드 케밥 케이스 적용

### DIFF
--- a/roome/src/test/java/com/roome/domain/cdcomment/controller/CdCommentControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/cdcomment/controller/CdCommentControllerTest.java
@@ -48,7 +48,7 @@ class CdCommentControllerTest {
     BDDMockito.given(cdCommentService.addComment(any(Long.class), any(Long.class), any(CdCommentCreateRequest.class)))
         .willReturn(response);
 
-    mockMvc.perform(post("/api/mycd/1/comment")
+    mockMvc.perform(post("/api/my-cd/1/comment")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
             .with(csrf()))
@@ -68,7 +68,7 @@ class CdCommentControllerTest {
     BDDMockito.given(cdCommentService.getComments(eq(1L), any(Integer.class), any(Integer.class)))
         .willReturn(response);
 
-    mockMvc.perform(get("/api/mycd/1/comments")
+    mockMvc.perform(get("/api/my-cd/1/comments")
             .param("page", "0")
             .param("size", "5")
             .accept(MediaType.APPLICATION_JSON))
@@ -87,7 +87,7 @@ class CdCommentControllerTest {
     BDDMockito.given(cdCommentService.searchComments(eq(1L), eq("최고"), any(Integer.class), any(Integer.class)))
         .willReturn(response);
 
-    mockMvc.perform(get("/api/mycd/1/comments/search")
+    mockMvc.perform(get("/api/my-cd/1/comments/search")
             .param("query", "최고")
             .param("page", "0")
             .param("size", "5")
@@ -100,7 +100,7 @@ class CdCommentControllerTest {
   @WithMockUser
   @Test
   void deleteComment_Success() throws Exception {
-    mockMvc.perform(delete("/api/mycd/comments/1")
+    mockMvc.perform(delete("/api/my-cd/comments/1")
             .with(csrf()))
         .andExpect(status().isNoContent());
 
@@ -111,7 +111,7 @@ class CdCommentControllerTest {
   @WithMockUser
   @Test
   void deleteMultipleComments_Success() throws Exception {
-    mockMvc.perform(delete("/api/mycd/comments")
+    mockMvc.perform(delete("/api/my-cd/comments")
             .param("commentIds", "1", "2", "3")
             .with(csrf()))
         .andExpect(status().isNoContent());

--- a/roome/src/test/java/com/roome/domain/cdtemplate/controller/CdTemplateControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/cdtemplate/controller/CdTemplateControllerTest.java
@@ -45,7 +45,7 @@ class CdTemplateControllerTest {
     BDDMockito.given(cdTemplateService.createTemplate(eq(1L), eq(1L), any(CdTemplateRequest.class)))
         .willReturn(response);
 
-    mockMvc.perform(post("/api/mycd/1/template")
+    mockMvc.perform(post("/api/my-cd/1/template")
             .param("userId", "1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
@@ -63,7 +63,7 @@ class CdTemplateControllerTest {
 
     BDDMockito.given(cdTemplateService.getTemplate(eq(1L))).willReturn(response);
 
-    mockMvc.perform(get("/api/mycd/1/template")
+    mockMvc.perform(get("/api/my-cd/1/template")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.comment1").value("CD를 듣게 된 계기"));
@@ -79,7 +79,7 @@ class CdTemplateControllerTest {
     BDDMockito.given(cdTemplateService.updateTemplate(eq(1L), eq(1L), any(CdTemplateRequest.class)))
         .willReturn(response);
 
-    mockMvc.perform(patch("/api/mycd/1/template")
+    mockMvc.perform(patch("/api/my-cd/1/template")
             .param("userId", "1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
@@ -92,7 +92,7 @@ class CdTemplateControllerTest {
   @DisplayName("CD 템플릿 삭제 성공")
   @WithMockUser
   void deleteTemplate_Success() throws Exception {
-    mockMvc.perform(delete("/api/mycd/1/template")
+    mockMvc.perform(delete("/api/my-cd/1/template")
             .param("userId", "1")
             .with(csrf()))
         .andExpect(status().isNoContent());

--- a/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
@@ -49,7 +49,7 @@ class MyCdControllerTest {
     BDDMockito.given(myCdService.addCdToMyList(any(Long.class), any(MyCdCreateRequest.class)))
         .willReturn(response);
 
-    mockMvc.perform(post("/api/mycd")
+    mockMvc.perform(post("/api/my-cd")
             .param("userId", "1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
@@ -68,7 +68,7 @@ class MyCdControllerTest {
     BDDMockito.given(myCdService.addCdToMyList(any(Long.class), any(MyCdCreateRequest.class)))
         .willThrow(new MyCdAlreadyExistsException());
 
-    mockMvc.perform(post("/api/mycd")
+    mockMvc.perform(post("/api/my-cd")
             .param("userId", "1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
@@ -88,15 +88,11 @@ class MyCdControllerTest {
     BDDMockito.given(myCdService.getMyCdList(eq(1L), any(Long.class), any(Integer.class)))
         .willReturn(response);
 
-    String responseBody = mockMvc.perform(get("/api/mycd")
+    mockMvc.perform(get("/api/my-cd")
             .param("userId", "1")
             .param("size", "10")
             .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andReturn()
-        .getResponse()
-        .getContentAsString();
-
+        .andExpect(status().isOk());
   }
 
   @DisplayName("특정 CD 조회 성공")
@@ -108,7 +104,7 @@ class MyCdControllerTest {
     BDDMockito.given(myCdService.getMyCd(eq(1L), eq(1L)))
         .willReturn(response);
 
-    mockMvc.perform(get("/api/mycd/1")
+    mockMvc.perform(get("/api/my-cd/1")
             .param("userId", "1"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.title").value("Palette"));
@@ -121,18 +117,17 @@ class MyCdControllerTest {
     BDDMockito.given(myCdService.getMyCd(eq(1L), eq(999L)))
         .willThrow(new MyCdNotFoundException());
 
-    mockMvc.perform(get("/api/mycd/999")
+    mockMvc.perform(get("/api/my-cd/999")
             .param("userId", "1"))
         .andExpect(status().isNotFound())
         .andExpect(content().string(containsString(ErrorCode.MYCD_NOT_FOUND.getMessage())));
   }
 
-
   @DisplayName("CD 삭제 성공")
   @WithMockUser
   @Test
   void deleteMyCd_Success() throws Exception {
-    mockMvc.perform(delete("/api/mycd")
+    mockMvc.perform(delete("/api/my-cd")
             .param("userId", "1")
             .param("myCdIds", "1,2,3")
             .with(csrf()))
@@ -149,7 +144,7 @@ class MyCdControllerTest {
         .when(myCdService).delete(eq(1L), eq("999"));
 
     // when & then: 요청 후 404 응답을 기대
-    mockMvc.perform(delete("/api/mycd")
+    mockMvc.perform(delete("/api/my-cd")
             .param("userId", "1")
             .param("myCdIds", "999")
             .with(csrf()))


### PR DESCRIPTION
## 📌 PR 제목 refactor: 테스트 코드 API 경로 케밥 케이스 적용 (mycd → my-cd)

### ✅ PR 설명
테스트 코드에서 API 요청 경로를 기존 카멜 케이스(mycd)에서 케밥 케이스(my-cd)로 일관되게 변경하였습니다.
컨트롤러에서 실제 사용되는 API 경로와 일치하도록 수정하였습니다.

### 🏗 작업 내용
 - [ ] CdCommentControllerTest: /api/mycd → /api/my-cd 변경
 - [ ] CdTemplateControllerTest: /api/mycd → /api/my-cd 변경
 - [ ] MyCdControllerTest: /api/mycd → /api/my-cd 변경
 - [ ] 컨트롤러의 API 경로와 테스트 코드가 일치하도록 수정
 - [ ] 변경된 API 경로에 맞춰 테스트 정상 동작 여부 확인

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
