### PR TITLE
Feat: Redis 기반 인증/인가 로직 및 보안 설정 추가

### DIFF
--- a/roome/build.gradle
+++ b/roome/build.gradle
@@ -73,6 +73,10 @@ dependencies {
 	// AWS
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.0.3'
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.3'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 bootJar {

--- a/roome/src/main/java/com/roome/RoomeApplication.java
+++ b/roome/src/main/java/com/roome/RoomeApplication.java
@@ -1,9 +1,12 @@
 package com.roome;
 
+import io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@EnableAutoConfiguration(exclude = {S3AutoConfiguration.class}) // temp: s3 에러로 인한 자동 설정 제외
 public class RoomeApplication {
 
 	public static void main(String[] args) {

--- a/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
+++ b/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
@@ -142,9 +142,10 @@ public class AuthController {
             Long userId = tokenService.getUserIdFromToken(accessToken);
             userService.deleteUser(userId);
 
+            redisService.deleteRefreshToken(userId.toString());
+
             // 토큰 무효화
             tokenResponseHelper.removeTokenResponse(response);
-
             return ResponseEntity.ok(new MessageResponse("회원 탈퇴가 완료되었습니다."));
 
         } catch (InvalidRefreshTokenException e) {

--- a/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
+++ b/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
@@ -119,12 +119,6 @@ public class AuthController {
             HttpServletResponse response
     ) {
         try {
-            // Authorization 헤더 검증
-            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(new MessageResponse("인증 토큰이 필요합니다."));
-            }
-
             String accessToken = authHeader.substring(7);
 
             if (accessToken.isBlank() || !jwtTokenProvider.validateAccessToken(accessToken)) {

--- a/roome/src/main/java/com/roome/global/config/CacheConfig.java
+++ b/roome/src/main/java/com/roome/global/config/CacheConfig.java
@@ -1,0 +1,9 @@
+package com.roome.global.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+}

--- a/roome/src/main/java/com/roome/global/config/RedisConfig.java
+++ b/roome/src/main/java/com/roome/global/config/RedisConfig.java
@@ -1,4 +1,3 @@
-/*
 package com.roome.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -43,6 +42,7 @@ public class RedisConfig {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
+        // JSON 직렬화 설정
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
 
         template.setKeySerializer(new StringRedisSerializer());
@@ -55,4 +55,3 @@ public class RedisConfig {
         return template;
     }
 }
-*/

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.roome.global.config;
 
 import com.roome.global.jwt.filter.JwtAuthenticationFilter;
 import com.roome.global.jwt.service.JwtTokenProvider;
+import com.roome.global.service.RedisService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +26,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, RedisService redisService) throws Exception {
         http
 
                 // CSRF 보호 비활성화
@@ -69,7 +70,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated());
 
-        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisService),
                 UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/roome/src/main/java/com/roome/global/exception/ErrorCode.java
+++ b/roome/src/main/java/com/roome/global/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
   INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "JWT 토큰이 유효하지 않거나, 입력값이 비어 있습니다."),
   INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."),
   MISSING_AUTHORITY(HttpStatus.UNAUTHORIZED, "해당 토큰에는 권한 정보가 포함되어 있지 않습니다."),
+  INVALID_USER_ID_FORMAT(HttpStatus.UNAUTHORIZED, "토큰의 userId 형식이 올바르지 않습니다."),
+  MISSING_USER_ID_FROM_TOKEN(HttpStatus.UNAUTHORIZED, "토큰에서 userId를 찾을 수 없습니다."),
 
   // User 관련 예외
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),

--- a/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
+++ b/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.roome.global.exception;
 
+import com.roome.domain.auth.dto.response.MessageResponse;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -32,5 +35,12 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .body(new ErrorResponse("데이터베이스 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value()));
+  }
+
+  // Authorization 헤더가 없는 경우 401 반환
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  public MessageResponse handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
+    return new MessageResponse("인증 토큰이 필요합니다.");
   }
 }

--- a/roome/src/main/java/com/roome/global/jwt/exception/InvalidUserIdFormatException.java
+++ b/roome/src/main/java/com/roome/global/jwt/exception/InvalidUserIdFormatException.java
@@ -1,0 +1,10 @@
+package com.roome.global.jwt.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class InvalidUserIdFormatException extends BusinessException {
+    public InvalidUserIdFormatException() {
+        super(ErrorCode.INVALID_USER_ID_FORMAT);
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/exception/MissingUserIdFromTokenException.java
+++ b/roome/src/main/java/com/roome/global/jwt/exception/MissingUserIdFromTokenException.java
@@ -1,0 +1,10 @@
+package com.roome.global.jwt.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class MissingUserIdFromTokenException extends BusinessException {
+    public MissingUserIdFromTokenException() {
+        super(ErrorCode.MISSING_USER_ID_FROM_TOKEN);
+    }
+}

--- a/roome/src/main/java/com/roome/global/jwt/service/JwtTokenProvider.java
+++ b/roome/src/main/java/com/roome/global/jwt/service/JwtTokenProvider.java
@@ -87,6 +87,19 @@ public class JwtTokenProvider {
         }
     }
 
+    // 액세스 토큰에서 유저 ID 추출
+    public String getUserIdFromToken(String accessToken) {
+        return parseClaims(accessToken).getSubject();
+    }
+
+    public long getRefreshTokenExpirationTime() {
+        return REFRESH_TOKEN_EXPIRE_TIME;
+    }
+
+    public long getAccessTokenExpirationTime() {
+        return ACCESS_TOKEN_EXPIRE_TIME;
+    }
+
     // Claims 파싱
     public Claims parseClaims(String accessToken) {
         try {

--- a/roome/src/main/java/com/roome/global/service/RedisService.java
+++ b/roome/src/main/java/com/roome/global/service/RedisService.java
@@ -1,0 +1,42 @@
+package com.roome.global.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+    private final StringRedisTemplate redisTemplate;
+    private static final String REFRESH_TOKEN_PREFIX = "RT:";
+    private static final String BLACKLIST_PREFIX = "BL:";
+
+    // Refresh Token 저장
+    public void saveRefreshToken(String userId, String refreshToken, long expiration) {
+        redisTemplate.opsForValue()
+                .set(REFRESH_TOKEN_PREFIX + userId, refreshToken, expiration, TimeUnit.MILLISECONDS);
+    }
+
+    // Refresh Token 조회
+    public String getRefreshToken(String userId) {
+        return redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+    // Refresh Token 삭제
+    public void deleteRefreshToken(String userId) {
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+    // 액세스 토큰 블랙리스트 추가
+    public void addToBlacklist(String accessToken, long expiration) {
+        redisTemplate.opsForValue()
+                .set(BLACKLIST_PREFIX + accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+    }
+
+    // 블랙리스트 토큰 확인
+    public boolean isBlacklisted(String accessToken) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + accessToken));
+    }
+}

--- a/roome/src/test/java/com/roome/domain/auth/controller/WithdrawControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/auth/controller/WithdrawControllerTest.java
@@ -1,169 +1,150 @@
 package com.roome.domain.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roome.domain.auth.service.OAuth2LoginService;
 import com.roome.domain.user.service.UserService;
-import com.roome.global.exception.BusinessException;
-import com.roome.global.exception.ErrorCode;
 import com.roome.global.jwt.dto.JwtToken;
 import com.roome.global.jwt.helper.TokenResponseHelper;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.jwt.service.TokenService;
+import com.roome.global.service.RedisService;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
 class WithdrawControllerTest {
 
+    @Autowired
     private MockMvc mockMvc;
 
-    @InjectMocks
-    private AuthController authController;
+    @MockBean
+    private OAuth2LoginService oAuth2LoginService;
 
-    @Mock
-    private UserService userService;
-
-    @Mock
-    private TokenService tokenService;
-
-    @Mock
+    @MockBean
     private JwtTokenProvider jwtTokenProvider;
 
-    @Mock
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private RedisService redisService;
+
+    @MockBean
     private TokenResponseHelper tokenResponseHelper;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final String validAccessToken = "validAccessToken";
-    private final String expiredAccessToken = "expiredAccessToken";
-    private final String validRefreshToken = "validRefreshToken";
-    private final String invalidRefreshToken = "invalidRefreshToken";
-
-    @BeforeEach
-    void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(authController).build();
-
-        lenient().when(jwtTokenProvider.validateAccessToken(anyString())).thenReturn(true);
-        lenient().when(tokenService.getUserIdFromToken(anyString())).thenReturn(1L);
-    }
-
     @Test
-    @DisplayName("회원 탈퇴 - 정상 요청")
-    void withdraw_Success() throws Exception {
+    @DisplayName("회원 탈퇴 성공 시 Access Token 블랙리스트 추가 및 Refresh Token 삭제")
+    void withdrawSuccess_BlacklistAndDeleteToken() throws Exception {
         // Given
-        when(jwtTokenProvider.validateAccessToken(validAccessToken)).thenReturn(true);
-        when(tokenService.getUserIdFromToken(validAccessToken)).thenReturn(1L);
-        doNothing().when(userService).deleteUser(1L);
+        String accessToken = "mockAccessToken";
+        String refreshToken = "mockRefreshToken";
+        Long userId = 1L;
+
+        when(jwtTokenProvider.validateAccessToken(accessToken)).thenReturn(true);
+        when(jwtTokenProvider.getAccessTokenExpirationTime()).thenReturn(3600000L); // 1시간 설정
+        when(tokenService.getUserIdFromToken(accessToken)).thenReturn(userId);
+        doNothing().when(redisService).deleteRefreshToken(userId.toString());
+        doNothing().when(redisService).addToBlacklist(eq(accessToken), anyLong());
+        doNothing().when(userService).deleteUser(userId);
 
         // When & Then
         mockMvc.perform(delete("/api/auth/withdraw")
-                        .header("Authorization", "Bearer " + validAccessToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
-    }
-
-    @Test
-    @DisplayName("회원 탈퇴 - 유효하지 않은 액세스 토큰 요청")
-    void withdraw_InvalidAccessToken() throws Exception {
-        // Given
-        when(jwtTokenProvider.validateAccessToken(validAccessToken)).thenReturn(false);
-
-        // When & Then
-        mockMvc.perform(delete("/api/auth/withdraw")
-                        .header("Authorization", "Bearer " + validAccessToken))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value("리프레시 토큰이 없거나 유효하지 않습니다."));
-    }
-
-    @Test
-    @DisplayName("회원 탈퇴 - 만료된 액세스 토큰 + 유효한 리프레시 토큰 사용")
-    void withdraw_ExpiredAccessToken_WithValidRefreshToken() throws Exception {
-        // Given
-        JwtToken newToken = new JwtToken("newAccessToken", validRefreshToken, "Bearer");
-
-        when(jwtTokenProvider.validateAccessToken(expiredAccessToken)).thenReturn(false);
-        when(jwtTokenProvider.validateRefreshToken(validRefreshToken)).thenReturn(true);
-        when(tokenService.reissueToken(validRefreshToken)).thenReturn(newToken);
-        doReturn(1L).when(tokenService).getUserIdFromToken(anyString());
-
-        doNothing().when(userService).deleteUser(1L);
-
-        // When & Then
-        mockMvc.perform(delete("/api/auth/withdraw")
-                        .header("Authorization", "Bearer " + expiredAccessToken)
-                        .cookie(new Cookie("refresh_token", validRefreshToken)))
+                        .header("Authorization", "Bearer " + accessToken)
+                        .cookie(new Cookie("refresh_token", refreshToken))
+                        .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
 
-        ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
-        verify(tokenService, times(1)).getUserIdFromToken(tokenCaptor.capture());
-
-        // 디버깅용
-        System.out.println("Captured Token: " + tokenCaptor.getValue());
+        // Verify: 블랙리스트 추가 & Refresh Token 삭제가 호출되었는지 확인
+        verify(redisService, times(1)).deleteRefreshToken(userId.toString());
+        verify(redisService, times(1)).addToBlacklist(eq(accessToken), anyLong());
     }
 
     @Test
-    @DisplayName("회원 탈퇴 - 유효하지 않은 리프레시 토큰 사용 시 실패")
-    void withdraw_InvalidRefreshToken() throws Exception {
+    @DisplayName("Access Token이 만료되었을 때 Refresh Token 검증 후 재발급")
+    void withdrawWithExpiredAccessToken_ReissueToken() throws Exception {
         // Given
-        when(jwtTokenProvider.validateAccessToken(expiredAccessToken)).thenReturn(false);
-        when(jwtTokenProvider.validateRefreshToken(invalidRefreshToken)).thenReturn(false);
+        String accessToken = "expiredAccessToken";
+        String refreshToken = "validRefreshToken";
+        Long userId = 1L;
+        JwtToken newToken = new JwtToken("newAccessToken", "newRefreshToken", "Bearer");
+
+        when(jwtTokenProvider.validateAccessToken(accessToken)).thenReturn(false); // 액세스 토큰 만료
+        when(jwtTokenProvider.validateRefreshToken(refreshToken)).thenReturn(true); // 리프레시 토큰 유효
+        when(jwtTokenProvider.getAccessTokenExpirationTime()).thenReturn(3600000L);
+        when(tokenService.reissueToken(refreshToken)).thenReturn(newToken);
+        when(tokenService.getUserIdFromToken(newToken.getAccessToken())).thenReturn(userId);
+        doNothing().when(redisService).deleteRefreshToken(userId.toString());
+        doNothing().when(redisService).addToBlacklist(eq(newToken.getAccessToken()), anyLong());
+        doNothing().when(userService).deleteUser(userId);
 
         // When & Then
         mockMvc.perform(delete("/api/auth/withdraw")
-                        .header("Authorization", "Bearer " + expiredAccessToken)
-                        .cookie(new Cookie("refresh_token", invalidRefreshToken)))
+                        .header("Authorization", "Bearer " + accessToken)
+                        .cookie(new Cookie("refresh_token", refreshToken))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
 
+        // Verify: 새 Access Token을 사용하여 회원 탈퇴 처리
+        verify(redisService, times(1)).deleteRefreshToken(userId.toString());
+        verify(redisService, times(1)).addToBlacklist(eq(newToken.getAccessToken()), anyLong());
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 없거나 유효하지 않을 때 탈퇴 실패 (401)")
+    void withdrawFail_InvalidRefreshToken() throws Exception {
+        // Given
+        String accessToken = "expiredAccessToken";
+        String refreshToken = "invalidRefreshToken";
+
+        when(jwtTokenProvider.validateAccessToken(accessToken)).thenReturn(false);
+        when(jwtTokenProvider.validateRefreshToken(refreshToken)).thenReturn(false); // 리프레시 토큰도 유효하지 않음
+
+        // When & Then
+        mockMvc.perform(delete("/api/auth/withdraw")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .cookie(new Cookie("refresh_token", refreshToken))
+                        .with(csrf()))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message").value("리프레시 토큰이 없거나 유효하지 않습니다."));
 
+        // Verify: Refresh Token이 유효하지 않아 삭제되지 않음
+        verify(redisService, times(0)).deleteRefreshToken(anyString());
     }
 
     @Test
-    @DisplayName("회원 탈퇴 - 존재하지 않는 사용자 ID 요청 시 실패")
-    void withdraw_UserNotFound() throws Exception {
+    @DisplayName("Authorization 헤더 없이 회원 탈퇴 시 401 반환")
+    void withdrawFail_NoAuthorizationToken() throws Exception {
         // Given
-        when(jwtTokenProvider.validateAccessToken(validAccessToken)).thenReturn(true);
-        when(tokenService.getUserIdFromToken(validAccessToken)).thenReturn(99L); // 존재하지 않는 ID
-        doThrow(new BusinessException(ErrorCode.USER_NOT_FOUND)).when(userService).deleteUser(99L);
+        String refreshToken = "validRefreshToken";
 
         // When & Then
         mockMvc.perform(delete("/api/auth/withdraw")
-                        .header("Authorization", "Bearer " + validAccessToken))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value(ErrorCode.USER_NOT_FOUND.getMessage()));
-    }
-
-    @Test
-    @DisplayName("회원 탈퇴 - 탈퇴 시 토큰 삭제 확인")
-    void withdraw_TokenRemoval() throws Exception {
-        // Given
-        when(jwtTokenProvider.validateAccessToken(validAccessToken)).thenReturn(true);
-        when(tokenService.getUserIdFromToken(validAccessToken)).thenReturn(1L);
-        doNothing().when(userService).deleteUser(1L);
-        doNothing().when(tokenResponseHelper).removeTokenResponse(any(HttpServletResponse.class));
-
-        // When & Then
-        mockMvc.perform(delete("/api/auth/withdraw")
-                        .header("Authorization", "Bearer " + validAccessToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
-
-        verify(tokenResponseHelper, times(1)).removeTokenResponse(any(HttpServletResponse.class));
+                        .cookie(new Cookie("refresh_token", refreshToken)) // ✅ 쿠키는 있지만 Authorization 없음
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## 📌 Feat: Redis 기반 인증/인가 로직 구현

### ✅ PR 설명
Redis를 활용한 인증/인가 로직을 적용하고, Refresh Token 및 Access Token 관리를 강화하였습니다.

### 🏗 작업 내용
- [ ] Redis 기반 인증/인가 로직 적용
- [ ] 회원 탈퇴 시 Access Token 블랙리스트 등록 및 Refresh Token 삭제
- [ ] AuthController 및 WithdrawController 테스트 수정
- [ ] 토큰 검증 및 예외 처리 개선

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> Redis를 활용한 인증/인가 로직이 추가됨에 따라, 로컬에서 Redis가 실행 중인지 확인 필요
