### PR TITLE
Feat/#138 feat point pointhistory entity

### DIFF
--- a/roome/src/main/java/com/roome/domain/point/entity/Point.java
+++ b/roome/src/main/java/com/roome/domain/point/entity/Point.java
@@ -1,0 +1,71 @@
+package com.roome.domain.point.entity;
+
+import com.roome.domain.point.exception.InsufficientPointsException;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "points")
+public class Point {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private Long userId;
+
+  @Column(nullable = false)
+  private int balance; // 현재 보유 포인트
+
+  @Column(nullable = false)
+  private int totalEarned; // 누적 적립 포인트
+
+  @Column(nullable = false)
+  private int totalUsed; // 누적 사용 포인트
+
+  @Column
+  private LocalDateTime lastGuestbookReward; // 마지막 방명록 보상 일자
+
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Builder
+  public Point(Long userId, int balance, int totalEarned, int totalUsed) {
+    this.userId = userId;
+    this.balance = balance;
+    this.totalEarned = totalEarned;
+    this.totalUsed = totalUsed;
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  // 포인트 적립
+  public void addPoints(int amount) {
+    this.balance += amount;
+    this.totalEarned += amount;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  // 포인트 사용
+  public void subtractPoints(int amount) {
+    if (this.balance < amount) {
+      throw new InsufficientPointsException();
+    }
+    this.balance -= amount;
+    this.totalUsed += amount;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  // 방명록 작성 보상 날짜 업데이트
+  public void updateLastGuestbookReward(LocalDateTime date) {
+    this.lastGuestbookReward = date;
+  }
+}

--- a/roome/src/main/java/com/roome/domain/point/entity/PointHistory.java
+++ b/roome/src/main/java/com/roome/domain/point/entity/PointHistory.java
@@ -1,0 +1,38 @@
+package com.roome.domain.point.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "point_history")
+public class PointHistory {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Column(nullable = false)
+  private int amount; // 변동된 포인트 양 (양수: 적립, 음수: 사용)
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private PointReason reason; // 적립/사용 사유
+
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public PointHistory(Long userId, int amount, PointReason reason) {
+    this.userId = userId;
+    this.amount = amount;
+    this.reason = reason;
+    this.createdAt = LocalDateTime.now();
+  }
+}

--- a/roome/src/main/java/com/roome/domain/point/entity/PointReason.java
+++ b/roome/src/main/java/com/roome/domain/point/entity/PointReason.java
@@ -1,0 +1,15 @@
+package com.roome.domain.point.entity;
+
+public enum PointReason {
+  // 포인트 적립
+  GUESTBOOK_REWARD,  // 방명록 작성 보상 (+10P, 1일 1회)
+  FIRST_COME_EVENT,  // 선착순 이벤트 보상 (랜덤 지급)
+  DAILY_ATTENDANCE,  // 출석 체크 보상 (하루 1회 랜덤 지급)
+
+  // 포인트 사용
+  THEME_PURCHASE,    // 테마 구매
+  BOOK_UNLOCK_LV2,   // 도서 제한 해제 (21~30권, 500P)
+  BOOK_UNLOCK_LV3,   // 도서 제한 해제 (31권 이상, 1500P)
+  CD_UNLOCK_LV2,     // CD 제한 해제 (21~30개, 500P)
+  CD_UNLOCK_LV3      // CD 제한 해제 (31개 이상, 1500P)
+}

--- a/roome/src/main/java/com/roome/domain/point/exception/InsufficientPointsException.java
+++ b/roome/src/main/java/com/roome/domain/point/exception/InsufficientPointsException.java
@@ -1,0 +1,10 @@
+package com.roome.domain.point.exception;
+
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+
+public class InsufficientPointsException extends BusinessException {
+  public InsufficientPointsException() {
+    super(ErrorCode.INSUFFICIENT_POINTS);
+  }
+}

--- a/roome/src/main/java/com/roome/global/exception/ErrorCode.java
+++ b/roome/src/main/java/com/roome/global/exception/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
 
   // User 관련 예외
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+  INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "닉네임 형식이 올바르지 않습니다."),
+  INVALID_BIO_LENGTH(HttpStatus.BAD_REQUEST, "자기소개는 30자를 초과할 수 없습니다."),
 
   // 페이지네이션 관련 예외
   INVALID_LIMIT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 limit 값입니다. (1-100 사이의 값을 입력해주세요)"),
@@ -73,18 +75,18 @@ public enum ErrorCode {
   NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 알림에 접근 권한이 없습니다."),
   NOTIFICATION_EXPIRED(HttpStatus.GONE, "만료된 알림입니다."),
   INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 알림 타입입니다."),
-  // 알림 생성 요청 검증
-    INVALID_NOTIFICATION_REQUEST(HttpStatus.BAD_REQUEST, "알림 생성 요청이 유효하지 않습니다."),
-  //서버 에러
-  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다."),
-  // User 프로필 관련 예외
-  INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "닉네임 형식이 올바르지 않습니다."),
-  INVALID_BIO_LENGTH(HttpStatus.BAD_REQUEST, "자기소개는 30자를 초과할 수 없습니다."),
-  // 유저 Genre 관련 예외 추가
+  INVALID_NOTIFICATION_REQUEST(HttpStatus.BAD_REQUEST, "알림 생성 요청이 유효하지 않습니다."),
+
+  // 유저 Genre 관련 예외
   GENRE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "장르는 최대 3개까지만 선택할 수 있습니다."),
   DUPLICATE_GENRE(HttpStatus.BAD_REQUEST, "이미 선택된 장르입니다."),
   INVALID_GENRE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 장르 타입입니다."),
-  ;
+
+  // Point 관련 예외
+  INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
+
+  // 서버 에러
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.");
 
   private final HttpStatus status;
   private final String message;


### PR DESCRIPTION
## 📌 feat: 포인트 도메인 및 예외 처리 추가

### ✅ PR 설명
포인트 시스템을 위한 엔티티를 설계하고, 포인트 적립/사용 내역을 관리하는 구조를 정의하였습니다.
포인트 부족 시 예외 처리를 추가하였으며, 포인트 관련 기능이 확장 가능하도록 설계하였습니다.

### 🏗 작업 내용
- [x] 포인트 도메인 엔티티 추가
 - Point 엔티티: 사용자 포인트 잔액 및 누적 포인트 관리
 - PointHistory 엔티티: 포인트 적립/사용 내역 관리
 - PointReason Enum 추가 (포인트 적립/사용 사유 정의)
 - [x] 포인트 예외 처리 추가
 - InsufficientPointsException 추가 (포인트 부족 예외)
 - ErrorCode에 INSUFFICIENT_POINTS 추가
 - Point 엔티티에서 포인트 차감 시 예외 처리 적용

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> #138 

### 🚨 참고 사항 (선택)
> 추후 포인트 적립 및 사용 API를 개발할 예정
이벤트 기능(선착순 이벤트, 출석 이벤트)과 연동 필요
