### PR TITLE
Refactor/#141 refactor add cd release date

### DIFF
--- a/roome/src/main/java/com/roome/domain/cd/entity/Cd.java
+++ b/roome/src/main/java/com/roome/domain/cd/entity/Cd.java
@@ -1,6 +1,7 @@
 package com.roome.domain.cd.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import lombok.*;
 
@@ -27,6 +28,9 @@ public class Cd {
   private String album;
 
   @Column(nullable = false)
+  private LocalDate releaseDate;
+
+  @Column(nullable = false)
   private String coverUrl;
 
   @Column(nullable = false)
@@ -38,12 +42,13 @@ public class Cd {
   @Builder.Default
   private List<CdGenre> cdGenres = new ArrayList<>();
 
-  public static Cd create(String title, String artist, String album, String coverUrl,
+  public static Cd create(String title, String artist, String album, LocalDate releaseDate, String coverUrl,
       String youtubeUrl, long duration) {
     return Cd.builder()
         .title(title)
         .artist(artist)
         .album(album)
+        .releaseDate(releaseDate)
         .coverUrl(coverUrl)
         .youtubeUrl(youtubeUrl)
         .duration(duration)

--- a/roome/src/main/java/com/roome/domain/mycd/controller/MockMyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MockMyCdController.java
@@ -6,6 +6,7 @@ import com.roome.domain.mycd.dto.MyCdResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,19 +22,11 @@ public class MockMyCdController {
   @PostMapping
   public ResponseEntity<MyCdResponse> addMyCd(
       @Parameter(description = "사용자 ID", required = true) @RequestParam("userId") Long userId,
-      @RequestBody MyCdCreateRequest request
-  ) {
-    MyCdResponse mockCd = new MyCdResponse(
-        1L, // 등록된 myCdId (임시 데이터)
+      @RequestBody MyCdCreateRequest request) {
+    MyCdResponse mockCd = new MyCdResponse(1L, // 등록된 myCdId (임시 데이터)
         100L, // 새롭게 등록된 CD의 ID (임시 데이터)
-        request.getTitle(),
-        request.getArtist(),
-        request.getAlbum(),
-        request.getGenres(),
-        request.getCoverUrl(),
-        request.getYoutubeUrl(),
-        request.getDuration()
-    );
+        request.getTitle(), request.getArtist(), request.getAlbum(), request.getReleaseDate(),
+        request.getGenres(), request.getCoverUrl(), request.getYoutubeUrl(), request.getDuration());
 
     return ResponseEntity.status(HttpStatus.CREATED).body(mockCd);
   }
@@ -43,16 +36,17 @@ public class MockMyCdController {
   public ResponseEntity<MyCdListResponse> getMyCdList(
       @Parameter(description = "사용자 ID", required = true) @RequestParam("userId") Long userId,
       @Parameter(description = "커서 기반 페이지네이션 (마지막 조회한 myCdId)") @RequestParam(value = "cursor", required = false) Long cursor,
-      @Parameter(description = "한 번에 가져올 개수 (기본값: 10)") @RequestParam(value = "size", defaultValue = "10") int size
-  ) {
+      @Parameter(description = "한 번에 가져올 개수 (기본값: 10)") @RequestParam(value = "size", defaultValue = "10") int size) {
     List<MyCdResponse> mockData = List.of(
         new MyCdResponse(1L, 1L, "Palette", "IU", "Palette",
+            LocalDate.of(2017, 4, 21),
             List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
             "https://youtube.com/watch?v=asdf5678", 215000),
+
         new MyCdResponse(2L, 2L, "The Red Shoes", "IU", "Modern Times",
+            LocalDate.of(2013, 10, 8),
             List.of("Jazz"), "https://example.com/image2.jpg",
-            "https://youtube.com/watch?v=zxcv1234", 245000)
-    );
+            "https://youtube.com/watch?v=zxcv1234", 245000));
 
     Long nextCursor = mockData.isEmpty() ? null : mockData.get(mockData.size() - 1).getMyCdId();
 
@@ -63,13 +57,11 @@ public class MockMyCdController {
   @GetMapping("/{myCdId}")
   public ResponseEntity<MyCdResponse> getMyCd(
       @Parameter(description = "사용자 ID", required = true) @RequestParam("userId") Long userId,
-      @Parameter(description = "조회할 CD의 ID") @PathVariable Long myCdId
-  ) {
-    MyCdResponse mockCd = new MyCdResponse(
-        myCdId, 1L, "Love Poem", "IU", "Love Poem",
+      @Parameter(description = "조회할 CD의 ID") @PathVariable Long myCdId) {
+    MyCdResponse mockCd = new MyCdResponse(myCdId, 1L, "Love Poem", "IU", "Love Poem",
+        LocalDate.of(2019, 11, 1),
         List.of("Ballad", "Pop"), "https://example.com/image6.jpg",
-        "https://youtube.com/watch?v=mnop9876", 240000
-    );
+        "https://youtube.com/watch?v=mnop9876", 240000);
 
     return ResponseEntity.ok(mockCd);
   }
@@ -78,8 +70,7 @@ public class MockMyCdController {
   @DeleteMapping
   public ResponseEntity<String> deleteMyCds(
       @Parameter(description = "사용자 ID", required = true) @RequestParam("userId") Long userId,
-      @Parameter(description = "삭제할 CD ID 목록 (예: 1,2,3)") @RequestParam List<Long> myCdIds
-  ) {
+      @Parameter(description = "삭제할 CD ID 목록 (예: 1,2,3)") @RequestParam List<Long> myCdIds) {
     return ResponseEntity.ok("userId=" + userId + " 삭제된 CD ID 목록: " + myCdIds);
   }
 
@@ -87,8 +78,7 @@ public class MockMyCdController {
   @DeleteMapping("/{myCdId}")
   public ResponseEntity<String> deleteMyCd(
       @Parameter(description = "사용자 ID", required = true) @RequestParam("userId") Long userId,
-      @Parameter(description = "삭제할 CD의 ID") @PathVariable Long myCdId
-  ) {
+      @Parameter(description = "삭제할 CD의 ID") @PathVariable Long myCdId) {
     return ResponseEntity.ok("userId=" + userId + " 삭제된 CD ID: " + myCdId);
   }
 }

--- a/roome/src/main/java/com/roome/domain/mycd/dto/MyCdCreateRequest.java
+++ b/roome/src/main/java/com/roome/domain/mycd/dto/MyCdCreateRequest.java
@@ -2,6 +2,7 @@ package com.roome.domain.mycd.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +22,9 @@ public class MyCdCreateRequest {
 
   @NotEmpty
   private String album;
+
+  @NotNull
+  private LocalDate releaseDate;
 
   @NotEmpty
   private List<String> genres;

--- a/roome/src/main/java/com/roome/domain/mycd/dto/MyCdResponse.java
+++ b/roome/src/main/java/com/roome/domain/mycd/dto/MyCdResponse.java
@@ -1,6 +1,7 @@
 package com.roome.domain.mycd.dto;
 
 import com.roome.domain.mycd.entity.MyCd;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class MyCdResponse {
   private String title;
   private String artist;
   private String album;
+  private LocalDate releaseDate;
   private List<String> genres;
   private String coverUrl;
   private String youtubeUrl;
@@ -27,6 +29,7 @@ public class MyCdResponse {
         .title(myCd.getCd().getTitle())
         .artist(myCd.getCd().getArtist())
         .album(myCd.getCd().getAlbum())
+        .releaseDate(myCd.getCd().getReleaseDate())
         .genres(myCd.getCd().getGenres())
         .coverUrl(myCd.getCd().getCoverUrl())
         .youtubeUrl(myCd.getCd().getYoutubeUrl())

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -53,6 +53,7 @@ public class MyCdService {
               request.getTitle(),
               request.getArtist(),
               request.getAlbum(),
+              request.getReleaseDate(),
               request.getCoverUrl(),
               request.getYoutubeUrl(),
               request.getDuration()

--- a/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
@@ -8,6 +8,7 @@ import com.roome.domain.mycd.exception.MyCdAlreadyExistsException;
 import com.roome.domain.mycd.exception.MyCdNotFoundException;
 import com.roome.domain.mycd.service.MyCdService;
 import com.roome.global.exception.ErrorCode;
+import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
@@ -155,6 +156,7 @@ class MyCdControllerTest {
   private MyCdCreateRequest createMyCdCreateRequest() {
     return new MyCdCreateRequest(
         "Palette", "IU", "Palette",
+        LocalDate.of(2019, 11, 1),
         List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
         "https://youtube.com/watch?v=asdf5678", 215
     );
@@ -162,7 +164,7 @@ class MyCdControllerTest {
 
   private MyCdResponse createMyCdResponse(Long myCdId, MyCdCreateRequest request) {
     return new MyCdResponse(
-        myCdId, 1L, request.getTitle(), request.getArtist(), request.getAlbum(),
+        myCdId, 1L, request.getTitle(), request.getArtist(), request.getAlbum(), request.getReleaseDate(),
         request.getGenres(), request.getCoverUrl(), request.getYoutubeUrl(), request.getDuration()
     );
   }

--- a/roome/src/test/java/com/roome/domain/mycd/service/MyCdServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/service/MyCdServiceTest.java
@@ -17,6 +17,7 @@ import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.repository.RoomRepository;
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,7 @@ class MyCdServiceTest {
   void addCdToMyList_Success() {
     Long userId = 1L;
     MyCdCreateRequest request = new MyCdCreateRequest("Palette", "IU", "Palette",
+        LocalDate.of(2019, 11, 1),
         List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
         "https://youtube.com/watch?v=asdf5678", 215);
 
@@ -85,6 +87,7 @@ class MyCdServiceTest {
     // Given
     Long userId = 1L;
     MyCdCreateRequest request = new MyCdCreateRequest("Palette", "IU", "Palette",
+        LocalDate.of(2019, 11, 1),
         List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
         "https://youtube.com/watch?v=asdf5678", 215);
 


### PR DESCRIPTION
## 📌 feat: CD 엔티티 및 Mock API에 releaseDate 필드 추가 및 커서 기반 페이지네이션 적용

### ✅ PR 설명
CD 엔티티 및 관련 API에 releaseDate(발매일) 필드를 추가하고, 
Mock API의 CD 목록 조회 기능에 커서 기반 페이지네이션을 적용했습니다.

### 🏗 작업 내용
- feat: CD 엔티티에 releaseDate 필드 추가
  - 기존 CD 엔티티에 releaseDate 필드 추가
  - DB, DTO, 서비스 로직에 반영
- refactor: CD 관련 DTO 및 서비스 로직에 releaseDate 반영

  - MyCdCreateRequest, MyCdResponse 등에 releaseDate 필드 추가
  - MyCdService 내부 로직에서 releaseDate를 처리하도록 수정
- fix: MockMyCdController에 releaseDate 필드 반영

  - Mock 데이터 반환 시 releaseDate 값을 포함하도록 수정
- test: releaseDate 추가로 인한 테스트 코드 수정

  - MyCdServiceTest, MyCdControllerTest에서 releaseDate 필드 관련 검증 추가
- refactor: CD 목록 조회 Mock API 커서 기반 무한 스크롤 적용

  - 기존 Mock API는 30개 데이터를 무조건 반환했으나,
  커서 기반 페이지네이션(cursor, size)을 지원하도록 개선
  - cursor 값이 주어지면 해당 ID 이후의 데이터를 size 개수만큼 반환
  - 마지막 데이터 ID를 nextCursor 값으로 반환

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> #141 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
