### PR TITLE
Fix: 마지막 로그인 시간 업데이트 쿼리 수정, 마지막 로그인 시간 비교시 NPE 발생하지 않도록 비교 순서 변경

### DIFF
--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -101,7 +101,7 @@ public class User extends BaseTimeEntity {
 
     public boolean isAttendanceToday(LocalDateTime now) {
         LocalDateTime midnight = now.with(LocalTime.MIDNIGHT);
-        return lastLogin.isEqual(midnight) || lastLogin.isAfter(midnight);
+        return midnight.isEqual(lastLogin) || midnight.isAfter(lastLogin);
     }
 
     public void accumulatePoints(int amount) {

--- a/roome/src/main/java/com/roome/domain/user/repository/UserRepository.java
+++ b/roome/src/main/java/com/roome/domain/user/repository/UserRepository.java
@@ -25,7 +25,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query(
             value = """
-                    update attendance set last_login = :now where user_id = :userId
+                    update users set last_login = :now where user_id = :userId
                     """,
             nativeQuery = true
     )


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
해당 PR에서 수행한 작업을 간단히 설명해주세요.

### 🏗 작업 내용
- [ ] 마지막 로그인 시간 업데이트 쿼리 수정
- [ ] 마지막 로그인 시간 비교시 NPE 발생하지 않도록 비교 순서 변경

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
