### PR TITLE
Feat/#152 feat authenticateduser annotation

### DIFF
--- a/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
@@ -4,6 +4,7 @@ import com.roome.domain.mycd.dto.MyCdCreateRequest;
 import com.roome.domain.mycd.dto.MyCdListResponse;
 import com.roome.domain.mycd.dto.MyCdResponse;
 import com.roome.domain.mycd.service.MyCdService;
+import com.roome.global.auth.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,7 +19,7 @@ public class MyCdController {
 
   @PostMapping
   public ResponseEntity<MyCdResponse> addMyCd(
-      @RequestParam Long userId,
+      @AuthenticatedUser Long userId,
       @RequestBody @Valid MyCdCreateRequest myCdRequest
   ) {
     return ResponseEntity.ok(myCdService.addCdToMyList(userId, myCdRequest));

--- a/roome/src/main/java/com/roome/global/auth/AuthenticatedUser.java
+++ b/roome/src/main/java/com/roome/global/auth/AuthenticatedUser.java
@@ -1,0 +1,9 @@
+package com.roome.global.auth;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)  // 메서드 파라미터에만 적용
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AuthenticatedUser {
+}

--- a/roome/src/main/java/com/roome/global/auth/AuthenticatedUserArgumentResolver.java
+++ b/roome/src/main/java/com/roome/global/auth/AuthenticatedUserArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.roome.global.auth;
+
+import com.roome.global.exception.UnauthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.hasParameterAnnotation(AuthenticatedUser.class)
+        && parameter.getParameterType().equals(Long.class);
+  }
+
+  @Override
+  public Object resolveArgument(
+      MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory
+  ) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !authentication.isAuthenticated()) {
+      throw new UnauthorizedException();
+    }
+
+    return Long.valueOf(authentication.getName());  // JWT에서 가져온 userId 반환
+  }
+}

--- a/roome/src/main/java/com/roome/global/config/WebConfig.java
+++ b/roome/src/main/java/com/roome/global/config/WebConfig.java
@@ -1,15 +1,23 @@
 package com.roome.global.config;
 
+import com.roome.global.auth.AuthenticatedUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
     private static final String ALLOW_ALL_PATH = "/**";
     private static final String ALLOWED_METHODS = "*";
     private static final String FRONTEND_LOCALHOST = "http://localhost:5173";
+
+    private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
+
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -19,5 +27,10 @@ public class WebConfig implements WebMvcConfigurer {
                         FRONTEND_LOCALHOST
                 )
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedUserArgumentResolver);
     }
 }

--- a/roome/src/main/java/com/roome/global/exception/ErrorCode.java
+++ b/roome/src/main/java/com/roome/global/exception/ErrorCode.java
@@ -28,6 +28,9 @@ public enum ErrorCode {
   INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "닉네임 형식이 올바르지 않습니다."),
   INVALID_BIO_LENGTH(HttpStatus.BAD_REQUEST, "자기소개는 30자를 초과할 수 없습니다."),
 
+  // Auth 관련 예외
+  UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+
   // 페이지네이션 관련 예외
   INVALID_LIMIT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 limit 값입니다. (1-100 사이의 값을 입력해주세요)"),
   INVALID_CURSOR_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 cursor 값입니다."),

--- a/roome/src/main/java/com/roome/global/exception/UnauthorizedException.java
+++ b/roome/src/main/java/com/roome/global/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.roome.global.exception;
+
+public class UnauthorizedException extends ControllerException {
+  public UnauthorizedException() {
+    super(ErrorCode.UNAUTHORIZED_ACCESS);
+  }
+}

--- a/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
@@ -41,17 +41,16 @@ class MyCdControllerTest {
   private ObjectMapper objectMapper;
 
   @DisplayName("CD 추가 성공")
-  @WithMockUser
+  @WithMockUser(username = "1") // userId를 SecurityContext에 설정
   @Test
   void addMyCd_Success() throws Exception {
     MyCdCreateRequest request = createMyCdCreateRequest();
     MyCdResponse response = createMyCdResponse(1L, request);
 
-    BDDMockito.given(myCdService.addCdToMyList(any(Long.class), any(MyCdCreateRequest.class)))
+    BDDMockito.given(myCdService.addCdToMyList(eq(1L), any(MyCdCreateRequest.class)))
         .willReturn(response);
 
     mockMvc.perform(post("/api/my-cd")
-            .param("userId", "1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
             .with(csrf()))
@@ -61,16 +60,15 @@ class MyCdControllerTest {
   }
 
   @DisplayName("CD 추가 실패 - 중복 추가")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void addMyCd_Failure_AlreadyExists() throws Exception {
     MyCdCreateRequest request = createMyCdCreateRequest();
 
-    BDDMockito.given(myCdService.addCdToMyList(any(Long.class), any(MyCdCreateRequest.class)))
+    BDDMockito.given(myCdService.addCdToMyList(eq(1L), any(MyCdCreateRequest.class)))
         .willThrow(new MyCdAlreadyExistsException());
 
     mockMvc.perform(post("/api/my-cd")
-            .param("userId", "1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
             .with(csrf()))

--- a/roome/src/test/java/com/roome/global/auth/AuthenticatedUserArgumentResolverTest.java
+++ b/roome/src/test/java/com/roome/global/auth/AuthenticatedUserArgumentResolverTest.java
@@ -1,0 +1,99 @@
+package com.roome.global.auth;
+
+import com.roome.global.exception.UnauthorizedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class AuthenticatedUserArgumentResolverTest {
+
+  private AuthenticatedUserArgumentResolver resolver;
+  private MethodParameter methodParameter;
+  private NativeWebRequest webRequest;
+  private ModelAndViewContainer mavContainer;
+
+  @BeforeEach
+  void setUp() throws NoSuchMethodException {
+    resolver = new AuthenticatedUserArgumentResolver();
+    webRequest = mock(NativeWebRequest.class);
+    mavContainer = mock(ModelAndViewContainer.class);
+
+    methodParameter = mock(MethodParameter.class);
+    when(methodParameter.hasParameterAnnotation(AuthenticatedUser.class)).thenReturn(true);
+    when(methodParameter.getParameterType()).thenAnswer(invocation -> Long.class);
+  }
+
+  @Test
+  @DisplayName("Given 로그인한 사용자 When ArgumentResolver가 실행될 때 Then userId가 반환된다.")
+  void resolveArgument_Success() throws Exception {
+    // Given
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getName()).thenReturn("123"); // userId 설정
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    // When
+    Object resolvedArgument = resolver.resolveArgument(methodParameter, mavContainer, webRequest, null);
+
+    // Then
+    assertThat(resolvedArgument).isEqualTo(123L);
+  }
+
+  @Test
+  @DisplayName("Given 로그인하지 않은 사용자 When ArgumentResolver 실행 Then UnauthorizedException 발생")
+  void resolveArgument_NotAuthenticated_ThrowsException() {
+    // Given
+    SecurityContextHolder.clearContext(); // 로그인 안 된 상태
+
+    // When & Then
+    assertThatThrownBy(() -> resolver.resolveArgument(methodParameter, mavContainer, webRequest, null))
+        .isInstanceOf(UnauthorizedException.class);
+  }
+
+  @Test
+  @DisplayName("iven 인증되지 않은 사용자 When ArgumentResolver 실행 Then UnauthorizedException 발생")
+  void resolveArgument_AuthenticationNotValid_ThrowsException() {
+    // Given
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.isAuthenticated()).thenReturn(false);
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    // When & Then
+    assertThatThrownBy(() -> resolver.resolveArgument(methodParameter, mavContainer, webRequest, null))
+        .isInstanceOf(UnauthorizedException.class);
+  }
+
+  @Test
+  @DisplayName("Given userId가 숫자가 아닐 때 When ArgumentResolver 실행 Then NumberFormatException 발생")
+  void resolveArgument_InvalidUserIdFormat_ThrowsException() {
+    // Given
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getName()).thenReturn("invalid_user_id"); // 숫자가 아닌 값
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    // When & Then
+    assertThatThrownBy(() -> resolver.resolveArgument(methodParameter, mavContainer, webRequest, null))
+        .isInstanceOf(NumberFormatException.class);
+  }
+}


### PR DESCRIPTION

## 📌 PR 제목 feat: @AuthenticatedUser 기반 인증 기능 및 테스트 코드 추가

### ✅ PR 설명
@AuthenticatedUser 어노테이션을 활용하여 컨트롤러에서 userId를 자동으로 주입하는 기능을 구현하고, 관련 예외 처리 및 테스트를 추가했습니다.

### 🏗 작업 내용
 - [ ] @AuthenticatedUser 어노테이션 추가 (JWT 기반 사용자 인증)
 - [ ] AuthenticatedUserArgumentResolver 구현 (SecurityContextHolder에서 userId 추출)
 - [ ] UnauthorizedException 추가 및 ErrorCode.UNAUTHORIZED_ACCESS 등록 (401 처리)
 - [ ] MyCdController에서 @AuthenticatedUser 적용하여 userId 직접 받지 않도록 변경
 - [ ] WebConfig에 AuthenticatedUserArgumentResolver 등록
 - [ ] AuthenticatedUserArgumentResolverTest 작성 (단위 테스트)
 - [ ] MyCdControllerTest 수정 (@AuthenticatedUser 적용 반영한 통합 테스트)

### 📸 테스트 결과 (선택)
> 
<img width="861" alt="스크린샷 2025-02-26 11 46 07" src="https://github.com/user-attachments/assets/fd76d418-db89-4e84-9856-ad42bcacda1f" />
<img width="867" alt="스크린샷 2025-02-26 11 48 06" src="https://github.com/user-attachments/assets/358bd6fa-2806-4665-9843-187c5935a7c5" />
<img width="863" alt="스크린샷 2025-02-26 11 48 28" src="https://github.com/user-attachments/assets/1a04561c-45b2-4e5c-a555-ba6d97aad40f" />




### 🔗 관련 이슈 (선택)
> #152 

### 🚨 참고 사항 (선택)
> 이후 @AuthenticatedUser를 다른 컨트롤러에도 적용할 예정
