### PR TITLE
Feat/#156 feat mycdcontroller authenticateduser apply

### DIFF
--- a/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
@@ -6,7 +6,9 @@ import com.roome.domain.mycd.dto.MyCdResponse;
 import com.roome.domain.mycd.service.MyCdService;
 import com.roome.global.auth.AuthenticatedUser;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +24,8 @@ public class MyCdController {
       @AuthenticatedUser Long userId,
       @RequestBody @Valid MyCdCreateRequest myCdRequest
   ) {
-    return ResponseEntity.ok(myCdService.addCdToMyList(userId, myCdRequest));
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(myCdService.addCdToMyList(userId, myCdRequest));
   }
 
   @GetMapping

--- a/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
@@ -27,8 +27,8 @@ public class MyCdController {
 
   @GetMapping
   public ResponseEntity<MyCdListResponse> getMyCdList(
-      @RequestParam Long userId,
-      @RequestParam(value = "cursor", required = false) Long cursor,
+      @AuthenticatedUser Long userId,
+      @RequestParam(value = "cursor", required = false, defaultValue = "0") Long cursor,  // ✅ 기본값 0L 설정
       @RequestParam(value = "size", defaultValue = "10") int size
   ) {
     return ResponseEntity.ok(myCdService.getMyCdList(userId, cursor, size));
@@ -36,7 +36,7 @@ public class MyCdController {
 
   @GetMapping("/{myCdId}")
   public ResponseEntity<MyCdResponse> getMyCd(
-      @RequestParam Long userId,
+      @AuthenticatedUser Long userId,
       @PathVariable Long myCdId
   ) {
     return ResponseEntity.ok(myCdService.getMyCd(userId, myCdId));
@@ -44,8 +44,8 @@ public class MyCdController {
 
   @DeleteMapping
   public ResponseEntity<Void> delete(
-      @RequestParam Long userId,
-      @RequestParam String myCdIds
+      @AuthenticatedUser Long userId,
+      @RequestParam List<Long> myCdIds
   ) {
     myCdService.delete(userId, myCdIds);
     return ResponseEntity.noContent().build();

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -90,8 +90,7 @@ public class MyCdService {
     if (cursor == null) {
       myCds = myCdRepository.findByUserIdOrderByIdAsc(userId, PageRequest.of(0, size));
     } else {
-      myCds = myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor,
-          PageRequest.of(0, size));
+      myCds = myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor, PageRequest.of(0, size));
     }
 
     if (myCds.isEmpty()) {
@@ -110,18 +109,14 @@ public class MyCdService {
     return MyCdResponse.fromEntity(myCd);
   }
 
-  public void delete(Long userId, String myCdIds) {
+  public void delete(Long userId, List<Long> myCdIds) {
     validateUser(userId);
 
-    List<Long> ids = List.of(myCdIds.split(",")).stream()
-        .map(Long::parseLong)
-        .toList();
-
-    if (myCdRepository.findAllById(ids).isEmpty()) {
+    if (myCdRepository.findAllById(myCdIds).isEmpty()) {
       throw new MyCdNotFoundException();
     }
 
-    myCdRepository.deleteByUserIdAndIds(userId, ids);
+    myCdRepository.deleteByUserIdAndIds(userId, myCdIds);
   }
 
   private void validateUser(Long userId) {

--- a/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
@@ -54,7 +54,7 @@ class MyCdControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
             .with(csrf()))
-        .andExpect(status().isOk())
+        .andExpect(status().isCreated())
         .andExpect(jsonPath("$.title").value("Palette"))
         .andExpect(jsonPath("$.artist").value("IU"));
   }
@@ -68,10 +68,8 @@ class MyCdControllerTest {
     BDDMockito.given(myCdService.addCdToMyList(eq(1L), any(MyCdCreateRequest.class)))
         .willThrow(new MyCdAlreadyExistsException());
 
-    mockMvc.perform(post("/api/my-cd")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(request))
-            .with(csrf()))
+    mockMvc.perform(post("/api/my-cd").contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)).with(csrf()))
         .andExpect(status().isBadRequest())
         .andExpect(content().string(containsString(ErrorCode.MYCD_ALREADY_EXISTS.getMessage())));
   }
@@ -81,16 +79,12 @@ class MyCdControllerTest {
   @Test
   void getMyCdList_Success() throws Exception {
     MyCdListResponse response = new MyCdListResponse(
-        List.of(createMyCdResponse(1L, createMyCdCreateRequest())), 1L
-    );
+        List.of(createMyCdResponse(1L, createMyCdCreateRequest())), 1L);
 
     BDDMockito.given(myCdService.getMyCdList(eq(1L), any(Long.class), any(Integer.class)))
         .willReturn(response);
 
-    mockMvc.perform(get("/api/my-cd")
-            .param("userId", "1")
-            .param("size", "10")
-            .accept(MediaType.APPLICATION_JSON))
+    mockMvc.perform(get("/api/my-cd").param("size", "10").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
   }
 
@@ -100,12 +94,9 @@ class MyCdControllerTest {
   void getMyCd_Success() throws Exception {
     MyCdResponse response = createMyCdResponse(1L, createMyCdCreateRequest());
 
-    BDDMockito.given(myCdService.getMyCd(eq(1L), eq(1L)))
-        .willReturn(response);
+    BDDMockito.given(myCdService.getMyCd(eq(1L), eq(1L))).willReturn(response);
 
-    mockMvc.perform(get("/api/my-cd/1")
-            .param("userId", "1"))
-        .andExpect(status().isOk())
+    mockMvc.perform(get("/api/my-cd/1")).andExpect(status().isOk())
         .andExpect(jsonPath("$.title").value("Palette"));
   }
 
@@ -113,12 +104,9 @@ class MyCdControllerTest {
   @WithMockUser(username = "1")
   @Test
   void getMyCd_Failure_NotFound() throws Exception {
-    BDDMockito.given(myCdService.getMyCd(eq(1L), eq(999L)))
-        .willThrow(new MyCdNotFoundException());
+    BDDMockito.given(myCdService.getMyCd(eq(1L), eq(999L))).willThrow(new MyCdNotFoundException());
 
-    mockMvc.perform(get("/api/my-cd/999")
-            .param("userId", "1"))
-        .andExpect(status().isNotFound())
+    mockMvc.perform(get("/api/my-cd/999")).andExpect(status().isNotFound())
         .andExpect(content().string(containsString(ErrorCode.MYCD_NOT_FOUND.getMessage())));
   }
 
@@ -127,43 +115,37 @@ class MyCdControllerTest {
   @Test
   void deleteMyCd_Success() throws Exception {
     mockMvc.perform(delete("/api/my-cd")
-            .param("userId", "1")
-            .param("myCdIds", "1,2,3")
+            .param("myCdIds", "1")
+            .param("myCdIds", "2")
+            .param("myCdIds", "3")
             .with(csrf()))
         .andExpect(status().isNoContent());
 
-    BDDMockito.verify(myCdService).delete(1L, "1,2,3");
+    BDDMockito.verify(myCdService).delete(1L, List.of(1L, 2L, 3L));
   }
 
   @DisplayName("CD 삭제 실패 - 존재하지 않음")
   @WithMockUser(username = "1")
   @Test
   void deleteMyCd_Failure_NotFound() throws Exception {
-    BDDMockito.doThrow(new MyCdNotFoundException())
-        .when(myCdService).delete(eq(1L), eq("999"));
+    BDDMockito.doThrow(new MyCdNotFoundException()).when(myCdService)
+        .delete(eq(1L), eq(List.of(999L)));
 
     // when & then: 요청 후 404 응답을 기대
-    mockMvc.perform(delete("/api/my-cd")
-            .param("userId", "1")
-            .param("myCdIds", "999")
-            .with(csrf()))
+    mockMvc.perform(delete("/api/my-cd").param("myCdIds", "999").with(csrf()))
         .andExpect(status().isNotFound())
         .andExpect(content().string(containsString(ErrorCode.MYCD_NOT_FOUND.getMessage())));
   }
 
   private MyCdCreateRequest createMyCdCreateRequest() {
-    return new MyCdCreateRequest(
-        "Palette", "IU", "Palette",
-        LocalDate.of(2019, 11, 1),
+    return new MyCdCreateRequest("Palette", "IU", "Palette", LocalDate.of(2019, 11, 1),
         List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
-        "https://youtube.com/watch?v=asdf5678", 215
-    );
+        "https://youtube.com/watch?v=asdf5678", 215);
   }
 
   private MyCdResponse createMyCdResponse(Long myCdId, MyCdCreateRequest request) {
-    return new MyCdResponse(
-        myCdId, request.getTitle(), request.getArtist(), request.getAlbum(), request.getReleaseDate(),
-        request.getGenres(), request.getCoverUrl(), request.getYoutubeUrl(), request.getDuration()
-    );
+    return new MyCdResponse(myCdId, request.getTitle(), request.getArtist(), request.getAlbum(),
+        request.getReleaseDate(), request.getGenres(), request.getCoverUrl(),
+        request.getYoutubeUrl(), request.getDuration());
   }
 }

--- a/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
@@ -41,7 +41,7 @@ class MyCdControllerTest {
   private ObjectMapper objectMapper;
 
   @DisplayName("CD 추가 성공")
-  @WithMockUser(username = "1") // userId를 SecurityContext에 설정
+  @WithMockUser(username = "1")
   @Test
   void addMyCd_Success() throws Exception {
     MyCdCreateRequest request = createMyCdCreateRequest();
@@ -77,7 +77,7 @@ class MyCdControllerTest {
   }
 
   @DisplayName("내 CD 목록 조회 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void getMyCdList_Success() throws Exception {
     MyCdListResponse response = new MyCdListResponse(
@@ -95,7 +95,7 @@ class MyCdControllerTest {
   }
 
   @DisplayName("특정 CD 조회 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void getMyCd_Success() throws Exception {
     MyCdResponse response = createMyCdResponse(1L, createMyCdCreateRequest());
@@ -110,7 +110,7 @@ class MyCdControllerTest {
   }
 
   @DisplayName("특정 CD 조회 실패 - 존재하지 않음")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void getMyCd_Failure_NotFound() throws Exception {
     BDDMockito.given(myCdService.getMyCd(eq(1L), eq(999L)))
@@ -123,7 +123,7 @@ class MyCdControllerTest {
   }
 
   @DisplayName("CD 삭제 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void deleteMyCd_Success() throws Exception {
     mockMvc.perform(delete("/api/my-cd")
@@ -136,7 +136,7 @@ class MyCdControllerTest {
   }
 
   @DisplayName("CD 삭제 실패 - 존재하지 않음")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void deleteMyCd_Failure_NotFound() throws Exception {
     BDDMockito.doThrow(new MyCdNotFoundException())

--- a/roome/src/test/java/com/roome/domain/mycd/service/MyCdServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/service/MyCdServiceTest.java
@@ -52,39 +52,46 @@ class MyCdServiceTest {
   }
 
   @Test
-  @DisplayName("CD 추가 성공")
-  void addCdToMyList_Success() {
+  @DisplayName("새로운 CD 추가 성공")
+  void addCdToMyList_Success_NewCd() {
     Long userId = 1L;
-    MyCdCreateRequest request = new MyCdCreateRequest("Palette", "IU", "Palette",
-        LocalDate.of(2019, 11, 1),
-        List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
-        "https://youtube.com/watch?v=asdf5678", 215);
+    MyCdCreateRequest request = new MyCdCreateRequest(
+        "New Album", "New Artist", "New Album",
+        LocalDate.of(2022, 1, 1),
+        List.of("Pop"), "https://example.com/new_cd.jpg",
+        "https://youtube.com/watch?v=newvideo", 200
+    );
 
     User user = mock(User.class);
     Room room = mock(Room.class);
-    Cd cd = mock(Cd.class);
+    Cd newCd = mock(Cd.class);
     MyCd myCd = mock(MyCd.class);
     MyCdCount myCdCount = mock(MyCdCount.class);
 
     when(userRepository.findById(userId)).thenReturn(Optional.of(user));
     when(roomRepository.findByUserId(userId)).thenReturn(Optional.of(room));
-    when(cdRepository.findByTitleAndArtist(request.getTitle(), request.getArtist())).thenReturn(Optional.of(cd));
-    when(myCdRepository.existsByUserIdAndCdId(userId, 1L)).thenReturn(false);
+    when(cdRepository.findByTitleAndArtist(request.getTitle(), request.getArtist()))
+        .thenReturn(Optional.empty());
+    when(cdRepository.save(any(Cd.class))).thenReturn(newCd);
     when(myCdRepository.save(any(MyCd.class))).thenReturn(myCd);
     when(myCdCountRepository.findByRoom(room)).thenReturn(Optional.of(myCdCount));
-    when(myCd.getCd()).thenReturn(cd);
-    when(cd.getId()).thenReturn(1L);
+
+    when(myCd.getCd()).thenReturn(newCd);
+    when(newCd.getTitle()).thenReturn("New Album");
+    when(newCd.getArtist()).thenReturn("New Artist");
 
     MyCdResponse response = myCdService.addCdToMyList(userId, request);
 
     assertThat(response).isNotNull();
-    verify(myCdRepository, times(1)).save(any(MyCd.class));
+    assertThat(response.getTitle()).isEqualTo("New Album");
+    assertThat(response.getArtist()).isEqualTo("New Artist");
+
+    verify(cdRepository, times(1)).save(any(Cd.class));
   }
 
   @Test
   @DisplayName("CD 추가 실패 - 중복된 CD")
   void addCdToMyList_Failure_AlreadyExists() {
-    // Given
     Long userId = 1L;
     MyCdCreateRequest request = new MyCdCreateRequest("Palette", "IU", "Palette",
         LocalDate.of(2019, 11, 1),
@@ -109,15 +116,15 @@ class MyCdServiceTest {
     when(myCd.getCd()).thenReturn(cd);
     when(cd.getId()).thenReturn(1L);
 
-    // When & Then
     assertThatThrownBy(() -> myCdService.addCdToMyList(userId, request))
         .isInstanceOf(MyCdAlreadyExistsException.class);
   }
 
   @Test
-  @DisplayName("내 CD 목록 조회 성공")
-  void getMyCdList_Success() {
+  @DisplayName("내 CD 목록 조회 - 커서 기반 페이징 성공")
+  void getMyCdList_WithCursor_Success() {
     Long userId = 1L;
+    Long cursor = 5L;
     PageRequest pageRequest = PageRequest.of(0, 10);
 
     User user = mock(User.class);
@@ -125,7 +132,7 @@ class MyCdServiceTest {
     MyCd myCd = mock(MyCd.class);
 
     when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(myCdRepository.findByUserIdOrderByIdAsc(userId, pageRequest))
+    when(myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor, pageRequest))
         .thenReturn(List.of(myCd));
 
     when(myCd.getCd()).thenReturn(cd);
@@ -133,9 +140,39 @@ class MyCdServiceTest {
     when(cd.getId()).thenReturn(1L);
     when(cd.getTitle()).thenReturn("Palette");
     when(cd.getArtist()).thenReturn("IU");
-    when(cd.getAlbum()).thenReturn("Palette");
-    when(cd.getCoverUrl()).thenReturn("https://example.com/image1.jpg");
-    when(cd.getYoutubeUrl()).thenReturn("https://youtube.com/watch?v=asdf5678");
+
+    MyCdListResponse response = myCdService.getMyCdList(userId, cursor, 10);
+
+    assertThat(response).isNotNull();
+    assertThat(response.getData()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("내 CD 목록 조회 실패 - 보유한 CD 없음")
+  void getMyCdList_Failure_Empty() {
+    Long userId = 1L;
+    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
+    when(myCdRepository.findByUserIdOrderByIdAsc(userId, PageRequest.of(0, 10)))
+        .thenReturn(List.of());
+
+    assertThatThrownBy(() -> myCdService.getMyCdList(userId, null, 10))
+        .isInstanceOf(MyCdListEmptyException.class);
+  }
+
+  @Test
+  @DisplayName("내 CD 목록 조회 - cursor 없음")
+  void getMyCdList_Success_NoCursor() {
+    Long userId = 1L;
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    MyCd myCd = mock(MyCd.class);
+    Cd cd = mock(Cd.class);
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
+    when(myCdRepository.findByUserIdOrderByIdAsc(userId, pageRequest))
+        .thenReturn(List.of(myCd));
+
+    when(myCd.getCd()).thenReturn(cd);
+    when(myCd.getId()).thenReturn(1L);
 
     MyCdListResponse response = myCdService.getMyCdList(userId, null, 10);
 
@@ -144,16 +181,41 @@ class MyCdServiceTest {
   }
 
   @Test
-  @DisplayName("내 CD 목록 조회 실패 - 목록 없음")
-  void getMyCdList_Failure_Empty() {
+  @DisplayName("CD 단건 조회 - 존재하는 CD 조회 성공")
+  void getMyCd_Success() {
     Long userId = 1L;
-    PageRequest pageRequest = PageRequest.of(0, 10);
+    Long myCdId = 1L;
 
+    User user = mock(User.class);
+    Cd cd = mock(Cd.class);
+    MyCd myCd = mock(MyCd.class);
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(myCdRepository.findByIdAndUserId(myCdId, userId)).thenReturn(Optional.of(myCd));
+
+    when(myCd.getCd()).thenReturn(cd);
+    when(myCd.getId()).thenReturn(1L);
+    when(cd.getId()).thenReturn(1L);
+    when(cd.getTitle()).thenReturn("Palette");
+    when(cd.getArtist()).thenReturn("IU");
+
+    MyCdResponse response = myCdService.getMyCd(userId, myCdId);
+
+    assertThat(response).isNotNull();
+    assertThat(response.getTitle()).isEqualTo("Palette");
+  }
+
+
+  @Test
+  @DisplayName("CD 단건 조회 실패 - 존재하지 않음")
+  void getMyCd_Failure_NotFound() {
+    Long userId = 1L;
+    Long myCdId = 999L;
     when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
-    when(myCdRepository.findByUserIdOrderByIdAsc(userId, pageRequest)).thenReturn(List.of());
+    when(myCdRepository.findByIdAndUserId(myCdId, userId)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> myCdService.getMyCdList(userId, null, 10))
-        .isInstanceOf(MyCdListEmptyException.class);
+    assertThatThrownBy(() -> myCdService.getMyCd(userId, myCdId))
+        .isInstanceOf(MyCdNotFoundException.class);
   }
 
   @Test
@@ -165,7 +227,7 @@ class MyCdServiceTest {
     when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
     when(myCdRepository.findAllById(ids)).thenReturn(List.of(mock(MyCd.class), mock(MyCd.class)));
 
-    myCdService.delete(userId, "1,2,3");
+    myCdService.delete(userId, ids);
 
     verify(myCdRepository, times(1)).deleteByUserIdAndIds(userId, ids);
   }
@@ -179,7 +241,7 @@ class MyCdServiceTest {
     when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
     when(myCdRepository.findAllById(ids)).thenReturn(List.of());
 
-    assertThatThrownBy(() -> myCdService.delete(userId, "1,2,3"))
+    assertThatThrownBy(() -> myCdService.delete(userId, ids))
         .isInstanceOf(MyCdNotFoundException.class);
   }
 }


### PR DESCRIPTION
## 📌 MyCdController 개선 및 테스트 커버리지 향상

### ✅ PR 설명
- @AuthenticatedUser를 적용하여 userId 자동 주입
- 컨트롤러 및 서비스 로직에서 상태 코드 일관성 유지
- DELETE 요청 시 myCdIds 타입을 String → List<Long>으로 변경
- 테스트 코드 수정 및 커버리지 100% 달성

### 🏗 작업 내용
- MyCdController에서 @RequestParam userId 제거 후 @AuthenticatedUser 적용
- POST /api/my-cd 요청 시 201 Created 상태 코드 반환
 - DELETE /api/my-cd 요청 시 myCdIds를 List<Long>으로 받도록 수정
 - MyCdService.delete() 메서드에서 String 파싱 로직 제거
 - MyCdServiceTest 보완하여 테스트 커버리지 100% 달성
 - MyCdControllerTest 수정 및 @WithMockUser 적용
 - 예외 처리 (UnauthorizedException) 정상 동작 확인

### 📸 테스트 결과 (선택)
>
<img width="821" alt="스크린샷 2025-02-26 14 51 23" src="https://github.com/user-attachments/assets/4bbd6528-07fb-4910-a354-b278fc911019" />
<img width="795" alt="스크린샷 2025-02-26 14 51 45" src="https://github.com/user-attachments/assets/c443ed67-3499-4c43-becf-aa28e24b6896" />



### 🔗 관련 이슈 (선택)
> #156 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
