### PR TITLE
Feat: 프론트엔드 연동을 위한 인증 시스템 개선

### DIFF
--- a/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
+++ b/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
@@ -9,7 +9,6 @@ import com.roome.domain.user.repository.UserRepository;
 import com.roome.domain.user.service.UserService;
 import com.roome.global.exception.BusinessException;
 import com.roome.global.jwt.exception.InvalidRefreshTokenException;
-import com.roome.global.jwt.helper.TokenResponseHelper;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.jwt.service.TokenService;
 import com.roome.global.service.RedisService;
@@ -33,7 +32,6 @@ import java.util.Map;
 @Tag(name = "Authentication", description = "인증 관련 API")
 public class AuthController {
 
-    private final TokenResponseHelper tokenResponseHelper;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenService tokenService;
     private final UserService userService;
@@ -116,7 +114,7 @@ public class AuthController {
 
             if (accessToken.isBlank() || !jwtTokenProvider.validateAccessToken(accessToken)) {
                     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                            .body(new MessageResponse("리프레시 토큰이 없거나 유효하지 않습니다."));
+                            .body(new MessageResponse("유효하지 않은 액세스 토큰입니다."));
                 }
 
             // 유저 ID 추출 및 회원 탈퇴 처리

--- a/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
+++ b/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
@@ -1,16 +1,21 @@
 package com.roome.domain.auth.controller;
 
+import com.roome.domain.auth.dto.response.LoginResponse;
 import com.roome.domain.auth.dto.response.MessageResponse;
+import com.roome.domain.room.dto.RoomResponseDto;
+import com.roome.domain.room.service.RoomService;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
 import com.roome.domain.user.service.UserService;
 import com.roome.global.exception.BusinessException;
-import com.roome.global.jwt.dto.JwtToken;
 import com.roome.global.jwt.exception.InvalidRefreshTokenException;
 import com.roome.global.jwt.helper.TokenResponseHelper;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.jwt.service.TokenService;
 import com.roome.global.service.RedisService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import jakarta.servlet.http.HttpServletResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -25,20 +30,59 @@ import java.util.Map;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "bearerAuth")
+@Tag(name = "Authentication", description = "인증 관련 API")
 public class AuthController {
 
     private final TokenResponseHelper tokenResponseHelper;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenService tokenService;
     private final UserService userService;
+    private final UserRepository userRepository;
     private final RedisService redisService;
+    private final RoomService roomService;
+
+    @Operation(
+            summary = "사용자 정보 조회",
+            description = "Access Token으로 사용자 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @GetMapping("/user")
+    public ResponseEntity<LoginResponse> getUserInfo(
+            @RequestHeader("Authorization") String authHeader
+    ) {
+        try {
+            String accessToken = authHeader.substring(7);
+            Long userId = tokenService.getUserIdFromToken(accessToken);
+            User user = userRepository.getById(userId);
+            RoomResponseDto roomInfo = roomService.getOrCreateRoomByUserId(userId);
+
+            String refreshToken = redisService.getRefreshToken(userId.toString());
+
+            LoginResponse loginResponse = LoginResponse.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .expiresIn(jwtTokenProvider.getAccessTokenExpirationTime() / 1000) // 초 단위로 변환
+                    .user(LoginResponse.UserInfo.builder()
+                            .userId(user.getId())
+                            .nickname(user.getNickname())
+                            .email(user.getEmail())
+                            .roomId(roomInfo.getRoomId())
+                            .profileImage(user.getProfileImage())
+                            .build())
+                    .build();
+
+            return ResponseEntity.ok(loginResponse);
+        } catch (Exception e) {
+            log.error("사용자 정보 조회 중 오류: ", e);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(null);
+        }
+    }
 
     @Transactional
     @PostMapping("/logout")
     public ResponseEntity<?> logout(
-            @RequestHeader(value = "Authorization", required = false) String authHeader,
-            HttpServletResponse response
-    ) {
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
         try {
             if (authHeader != null && authHeader.startsWith("Bearer ")) {
                 String accessToken = authHeader.substring(7);
@@ -56,7 +100,6 @@ public class AuthController {
                 }
             }
 
-            tokenResponseHelper.removeTokenResponse(response);
             return ResponseEntity.ok(Map.of("message", "로그아웃 되었습니다."));
         } catch (Exception e) {
             log.error("로그아웃 중 오류 발생: ", e);
@@ -67,24 +110,14 @@ public class AuthController {
 
     @DeleteMapping("/withdraw")
     public ResponseEntity<MessageResponse> withdraw(
-            @RequestHeader("Authorization") String authHeader,
-            @CookieValue(value = "refresh_token", required = false) String refreshToken,
-            HttpServletResponse response
-    ) {
+            @RequestHeader("Authorization") String authHeader) {
         try {
             String accessToken = authHeader.substring(7);
 
             if (accessToken.isBlank() || !jwtTokenProvider.validateAccessToken(accessToken)) {
-                // 리프레시 토큰 검증
-                if (refreshToken == null || !jwtTokenProvider.validateRefreshToken(refreshToken)) {
                     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                             .body(new MessageResponse("리프레시 토큰이 없거나 유효하지 않습니다."));
                 }
-
-                // 유효하지 않은 액세스 토큰을 사용한 경우 새로운 액세스 토큰 발급
-                JwtToken newToken = tokenService.reissueToken(refreshToken);
-                accessToken = newToken.getAccessToken();
-            }
 
             // 유저 ID 추출 및 회원 탈퇴 처리
             Long userId = tokenService.getUserIdFromToken(accessToken);
@@ -96,8 +129,6 @@ public class AuthController {
             // Access Token 블랙리스트 추가
             redisService.addToBlacklist(accessToken, jwtTokenProvider.getAccessTokenExpirationTime());
 
-            // 클라이언트 측 토큰 삭제
-            tokenResponseHelper.removeTokenResponse(response);
             return ResponseEntity.ok(new MessageResponse("회원 탈퇴가 완료되었습니다."));
 
         } catch (InvalidRefreshTokenException e) {

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -99,7 +99,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://localhost:3000"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);
 

--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -1,9 +1,9 @@
 package com.roome.global.config;
 
 import com.roome.domain.auth.service.CustomOAuth2UserService;
+import com.roome.global.jwt.filter.JwtAuthenticationFilter;
 import com.roome.global.jwt.handler.OAuth2AuthenticationFailureHandler;
 import com.roome.global.jwt.handler.OAuth2AuthenticationSuccessHandler;
-import com.roome.global.jwt.filter.JwtAuthenticationFilter;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.service.RedisService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -27,83 +27,83 @@ import java.util.Arrays;
 @EnableWebSecurity
 public class SecurityConfig {
 
-  private final CustomOAuth2UserService oAuth2UserService;
-  private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
-  private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
-  private final JwtTokenProvider jwtTokenProvider;
-  private final RedisService redisService;
+    private final CustomOAuth2UserService oAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisService redisService;
 
-  @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF 보호 비활성화
+                .csrf(csrf -> csrf.disable())
 
-        // CSRF 보호 비활성화
-        .csrf(csrf -> csrf.disable())
+                // CORS 설정
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-        // CORS 설정
-        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-        .sessionManagement((session) -> session
-            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // X-Frame-Options 비활성화 (h2-console 접근 허용)
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
 
-        // X-Frame-Options 비활성화 (h2-console 접근 허용)
-        .headers(headers -> headers.frameOptions(frame -> frame.disable()))
-        // OAuth2 로그인 설정
-        .oauth2Login(oauth2 -> oauth2
-            .authorizationEndpoint(endpoint -> endpoint
-                .baseUri("/oauth2/authorization")
-            )
-            .redirectionEndpoint(endpoint -> endpoint
-                .baseUri("/login/oauth2/code/*")
-            )
-            .userInfoEndpoint(endpoint -> endpoint
-                .userService(oAuth2UserService)
-            )
-            .successHandler(oAuth2AuthenticationSuccessHandler)
-            .failureHandler(oAuth2AuthenticationFailureHandler)
-        )
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .baseUri("/oauth2/authorization")
+                        )
+                        .redirectionEndpoint(endpoint -> endpoint
+                                .baseUri("/login/oauth2/code/*")
+                        )
+                        .userInfoEndpoint(endpoint -> endpoint
+                                .userService(oAuth2UserService)
+                        )
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                        .failureHandler(oAuth2AuthenticationFailureHandler)
+                )
 
-        // 접근 제어 설정
-        .authorizeHttpRequests((auth) -> auth
-            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-            .requestMatchers(
-                "/**",
-                "/api/auth/**",
-                "/error",
-                "/v3/api-docs/**",
-                "/swagger-ui/**",
-                "/swagger-ui.html",
-                "/mock/**"
-            ).permitAll()
-            .anyRequest().authenticated()
-        )
+                // 접근 제어 설정
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(
+//                                "/**",
+                                "/api/auth/**",
+                                "/error",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/mock/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
 
-        // 예외 처리
-        .exceptionHandling(exception -> exception
-            .authenticationEntryPoint((request, response, authException) -> {
-              response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증되지 않은 사용자입니다.");
-            })
-            .accessDeniedHandler((request, response, accessDeniedException) -> {
-              response.sendError(HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
-            })
-        );
+                // 예외 처리
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.sendError(HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
+                        })
+                );
 
-    // JWT 필터 추가
-    http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisService),
-        UsernamePasswordAuthenticationFilter.class);
+        // JWT 필터 추가
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisService),
+                UsernamePasswordAuthenticationFilter.class);
 
-    return http.build();
-  }
+        return http.build();
+    }
 
-  @Bean
-  public CorsConfigurationSource corsConfigurationSource() {
-    CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173")); // 프론트엔드 URL
-    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-    configuration.setAllowedHeaders(Arrays.asList("*"));
-    configuration.setAllowCredentials(true);
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
 
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-    source.registerCorsConfiguration("/**", configuration);
-    return source;
-  }
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 }

--- a/roome/src/main/java/com/roome/global/config/SwaggerConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SwaggerConfig.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -19,32 +19,21 @@ public class SwaggerConfig {
      */
     @Bean
     public OpenAPI openAPI() {
-        // Bearer 토큰 스키마
-        SecurityScheme bearerAuth = new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")
-                .in(SecurityScheme.In.HEADER)
-                .name("Authorization");
-
-        // 리프레시 토큰 쿠키 스키마
-        SecurityScheme cookieAuth = new SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY)
-                .in(SecurityScheme.In.COOKIE)
-                .name("refresh_token");
-
-        // 기본 Security 요청 설정
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
-
         return new OpenAPI()
                 .info(new Info()
                         .title("Roome API")
                         .description("Roome 프로젝트 API 명세서")
                         .version("v1.0.0"))
-                // Security 설정
                 .components(new Components()
-                        .addSecuritySchemes("bearerAuth", bearerAuth)
-                        .addSecuritySchemes("cookieAuth", cookieAuth))
-                .security(Arrays.asList(securityRequirement));
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")
+                        )
+                )
+                .security(List.of(new SecurityRequirement().addList("bearerAuth")));
     }
+
 }

--- a/roome/src/main/java/com/roome/global/jwt/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/roome/src/main/java/com/roome/global/jwt/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,37 +1,32 @@
 package com.roome.global.jwt.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.roome.domain.auth.dto.response.LoginResponse;
 import com.roome.domain.auth.security.OAuth2UserPrincipal;
-import com.roome.domain.room.dto.RoomResponseDto;
-import com.roome.domain.room.service.RoomService;
 import com.roome.domain.user.entity.User;
 import com.roome.global.jwt.dto.JwtToken;
-import com.roome.global.jwt.helper.TokenResponseHelper;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.service.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisService redisService;
-    private final RoomService roomService;
-    private final ObjectMapper objectMapper;
-    private final TokenResponseHelper tokenResponseHelper;
+
+    @Value("${app.oauth2.redirectUri}")
+    private String redirectUri;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -51,50 +46,15 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
                 jwtTokenProvider.getRefreshTokenExpirationTime()
         );
 
-        try {
-            // 방 정보 조회
-            RoomResponseDto roomInfo = roomService.getOrCreateRoomByUserId(user.getId());
+        // 프론트엔드 리다이렉트 URI에 액세스 토큰을 쿼리 파라미터로 추가
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("accessToken", jwtToken.getAccessToken())
+                .queryParam("userId", user.getId())
+                .build().toUriString();
 
-            // 응답 객체 생성
-            LoginResponse loginResponse = LoginResponse.builder()
-                    .accessToken(jwtToken.getAccessToken())
-                    .refreshToken(jwtToken.getRefreshToken())
-                    .expiresIn(3600L)
-                    .user(LoginResponse.UserInfo.builder()
-                            .userId(user.getId())
-                            .nickname(user.getNickname())
-                            .email(user.getEmail())
-                            .roomId(roomInfo.getRoomId())
-                            .profileImage(user.getProfileImage())
-                            .build())
-                    .build();
+        log.info("리다이렉트 URL: {}", targetUrl);
 
-            // 토큰을 쿠키/헤더에 설정
-            tokenResponseHelper.setTokenResponse(response, jwtToken);
-
-            // 응답 설정
-            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            response.setCharacterEncoding("UTF-8");
-            response.getWriter().write(objectMapper.writeValueAsString(loginResponse));
-
-        } catch (Exception e) {
-            log.error("OAuth2 성공 처리 중 오류: {}", e.getMessage(), e);
-
-            // 오류 발생해도 최소한의 로그인 응답은 전송
-            Map<String, Object> errorResponse = Map.of(
-                    "accessToken", jwtToken.getAccessToken(),
-                    "refreshToken", jwtToken.getRefreshToken(),
-                    "expiresIn", 3600L,
-                    "error", "방 정보를 불러오는 중 오류가 발생했습니다."
-            );
-
-            // 토큰을 쿠키/헤더에 설정
-            tokenResponseHelper.setTokenResponse(response, jwtToken);
-
-            // 응답 설정
-            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            response.setCharacterEncoding("UTF-8");
-            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
-        }
+        // 리다이렉트
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/roome/src/main/resources/application.yml
+++ b/roome/src/main/resources/application.yml
@@ -51,6 +51,15 @@ spring:
   jwt:
     secret: ${JWT_SECRET}
 
+# OAuth2 리디렉션 설정
+app:
+  oauth2:
+    redirectUri: http://localhost:5173/oauth/callback
+  cors:
+    allowed-origins:
+      - http://localhost:5173
+      - http://localhost:3000
+
 server:
   shutdown: graceful
 

--- a/roome/src/test/java/com/roome/domain/auth/controller/AuthControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/auth/controller/AuthControllerTest.java
@@ -1,10 +1,9 @@
 package com.roome.domain.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roome.domain.room.service.RoomService;
+import com.roome.domain.user.repository.UserRepository;
 import com.roome.domain.user.service.UserService;
-import com.roome.global.jwt.handler.OAuth2AuthenticationFailureHandler;
-import com.roome.global.jwt.handler.OAuth2AuthenticationSuccessHandler;
-import com.roome.global.jwt.helper.TokenResponseHelper;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.jwt.service.TokenService;
 import com.roome.global.service.RedisService;
@@ -24,7 +23,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(AuthController.class)
+@WebMvcTest(controllers = AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
@@ -36,9 +35,6 @@ class AuthControllerTest {
     private JwtTokenProvider jwtTokenProvider;
 
     @MockBean
-    private TokenResponseHelper tokenResponseHelper;
-
-    @MockBean
     private TokenService tokenService;
 
     @MockBean
@@ -48,10 +44,10 @@ class AuthControllerTest {
     private RedisService redisService;
 
     @MockBean
-    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private UserRepository userRepository;
 
     @MockBean
-    private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private RoomService roomService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/roome/src/test/java/com/roome/global/jwt/handler/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/roome/src/test/java/com/roome/global/jwt/handler/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,19 +1,15 @@
 package com.roome.global.jwt.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.roome.domain.auth.dto.response.LoginResponse;
 import com.roome.domain.auth.security.OAuth2UserPrincipal;
-import com.roome.domain.room.dto.RoomResponseDto;
-import com.roome.domain.room.service.RoomService;
 import com.roome.domain.user.entity.Provider;
 import com.roome.domain.user.entity.Status;
 import com.roome.domain.user.entity.User;
 import com.roome.global.jwt.dto.JwtToken;
-import com.roome.global.jwt.helper.TokenResponseHelper;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.service.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,10 +20,11 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -45,17 +42,18 @@ class OAuth2AuthenticationSuccessHandlerTest {
     private RedisService redisService;
 
     @Mock
-    private RoomService roomService;
+    private RedirectStrategy redirectStrategy;
 
-    @Mock
-    private ObjectMapper objectMapper;
-
-    @Mock
-    private TokenResponseHelper tokenResponseHelper;
+    @BeforeEach
+    void setUp() {
+        // 테스트를 위한 redirectUri 설정
+        ReflectionTestUtils.setField(successHandler, "redirectUri", "http://localhost:5173/oauth/callback");
+        successHandler.setRedirectStrategy(redirectStrategy);
+    }
 
     @Test
-    @DisplayName("인증 성공 시 JWT 토큰이 발급되고 Redis에 저장된다")
-    void onAuthenticationSuccess_GeneratesTokenAndSavesToRedis() throws IOException {
+    @DisplayName("인증 성공 시 JWT 토큰이 발급되고 Redis에 저장되며, 프론트엔드로 리다이렉트된다")
+    void onAuthenticationSuccess_GeneratesTokenAndRedirects() throws IOException {
         // Given
         HttpServletRequest request = new MockHttpServletRequest();
         HttpServletResponse response = new MockHttpServletResponse();
@@ -82,33 +80,10 @@ class OAuth2AuthenticationSuccessHandlerTest {
                 .refreshToken("test-refresh-token")
                 .build();
 
-        RoomResponseDto roomResponseDto = RoomResponseDto.builder()
-                .roomId(1L)
-                .userId(1L)
-                .theme("BASIC")
-                .furnitures(Collections.emptyList())
-                .build();
-
-        LoginResponse loginResponse = LoginResponse.builder()
-                .accessToken(jwtToken.getAccessToken())
-                .refreshToken(jwtToken.getRefreshToken())
-                .expiresIn(3600L)
-                .user(LoginResponse.UserInfo.builder()
-                        .userId(user.getId())
-                        .nickname(user.getNickname())
-                        .email(user.getEmail())
-                        .roomId(roomResponseDto.getRoomId())
-                        .profileImage(user.getProfileImage())
-                        .build())
-                .build();
-
-        String loginResponseJson = "{\"accessToken\":\"test-access-token\"}";
-
+        // Mocking
         when(jwtTokenProvider.createToken(anyString())).thenReturn(jwtToken);
-        when(roomService.getOrCreateRoomByUserId(anyLong())).thenReturn(roomResponseDto);
-        when(objectMapper.writeValueAsString(any(LoginResponse.class))).thenReturn(loginResponseJson);
-        doNothing().when(tokenResponseHelper).setTokenResponse(any(), any());
         doNothing().when(redisService).saveRefreshToken(anyString(), anyString(), anyLong());
+        doNothing().when(redirectStrategy).sendRedirect(any(), any(), anyString());
 
         // When
         successHandler.onAuthenticationSuccess(request, response, authentication);
@@ -120,7 +95,17 @@ class OAuth2AuthenticationSuccessHandlerTest {
                 eq(jwtToken.getRefreshToken()),
                 anyLong()
         );
-        verify(tokenResponseHelper).setTokenResponse(response, jwtToken);
-        verify(objectMapper).writeValueAsString(any(LoginResponse.class));
+
+        // 리다이렉트 검증 - URL에 액세스 토큰과 사용자 ID가 포함되어야 함
+        verify(redirectStrategy).sendRedirect(
+                eq(request),
+                eq(response),
+                contains("accessToken=test-access-token")
+        );
+        verify(redirectStrategy).sendRedirect(
+                eq(request),
+                eq(response),
+                contains("userId=1")
+        );
     }
 }


### PR DESCRIPTION
## 📌 Feat: 프론트엔드 연동을 위한 인증 시스템 개선

### ✅ PR 설명
프론트엔드와 백엔드 간 원활한 인증 연동을 위해 OAuth2 로그인 후 리다이렉트 방식을 도입하고 토큰 관리 방식을 개선했습니다.

### 🏗 작업 내용
- [ ] OAuth2 로그인 후 액세스 토큰을 쿼리 파라미터로 전달하도록 개선
- [ ] 사용자 정보 조회 API 추가 (/api/auth/user)
- [ ] 시큐리티 설정에서 CORS 허용 출처 확장 및 보안 설정 개선
- [ ] 테스트 코드 업데이트 - 변경된 인증 흐름에 맞게 수정

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 프론트엔드에서는 OAuth2 로그인 버튼 클릭 시 백엔드 /oauth2/authorization/{provider} 엔드포인트로 요청을 보내야 합니다.
인증 성공 시 http://localhost:5173/oauth/callback?accessToken=xxxx&userId=123 형태로 리다이렉트됩니다.
프론트엔드는 액세스 토큰을 저장하고 /api/auth/user API를 호출하여 사용자 정보와 리프레시 토큰을 얻을 수 있습니다.
액세스 토큰 만료 시 /api/auth/reissue-token API를 호출하여 새 토큰을 발급받아야 합니다.
