### PR TITLE
Test: OAuth2 로그인 및 토큰 재발급 테스트 수정 및 추가

### DIFF
--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/roome/src/test/java/com/roome/global/jwt/controller/ReissueControllerTest.java
+++ b/roome/src/test/java/com/roome/global/jwt/controller/ReissueControllerTest.java
@@ -1,0 +1,103 @@
+package com.roome.global.jwt.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roome.global.jwt.dto.JwtToken;
+import com.roome.global.jwt.service.JwtTokenProvider;
+import com.roome.global.jwt.service.TokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ReissueController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith(MockitoExtension.class)
+class ReissueControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("유효한 리프레시 토큰으로 액세스 토큰 재발급 성공")
+    void reissueToken_Success() throws Exception {
+        // Given
+        String refreshToken = "valid-refresh-token";
+        JwtToken newToken = new JwtToken(
+                "Bearer",
+                "new-access-token",
+                "new-refresh-token"
+        );
+
+        Map<String, String> requestBody = Map.of("refreshToken", refreshToken);
+
+        when(jwtTokenProvider.validateRefreshToken(refreshToken)).thenReturn(true);
+        when(tokenService.reissueToken(refreshToken)).thenReturn(newToken);
+        when(jwtTokenProvider.getAccessTokenExpirationTime()).thenReturn(3600000L);
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestBody))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("new-access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("new-refresh-token"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.expiresIn").value(3600));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰이 없는 경우 재발급 실패")
+    void reissueToken_NoRefreshToken_Failure() throws Exception {
+        // Given
+        Map<String, String> requestBody = Map.of();
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestBody))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("리프레시 토큰이 필요합니다."));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰으로 재발급 실패")
+    void reissueToken_InvalidRefreshToken_Failure() throws Exception {
+        // Given
+        String refreshToken = "invalid-refresh-token";
+        Map<String, String> requestBody = Map.of("refreshToken", refreshToken);
+
+        when(jwtTokenProvider.validateRefreshToken(refreshToken)).thenReturn(false);
+
+        // When & Then
+        mockMvc.perform(post("/api/auth/reissue-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestBody))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("유효하지 않은 리프레시 토큰입니다."));
+    }
+}


### PR DESCRIPTION
## 📌 Test: OAuth2 로그인 및 토큰 재발급 테스트 수정 및 추가

### ✅ PR 설명
PointHistoryRepository를 Mock으로 추가하여 NullPointerException을 해결하고, 리프레시 토큰을 이용한 액세스 토큰 재발급 테스트를 추가했습니다.

### 🏗 작업 내용
- [ ] CustomOAuth2UserServiceTest에서 PointHistoryRepository를 Mock으로 추가
- [ ] ReissueControllerTest: 리프레시 토큰을 이용한 액세스 토큰 재발급 테스트 추가

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
