### PR TITLE
Feat/#159 cdcommentcontroller authenticateduser apply

### DIFF
--- a/roome/src/main/java/com/roome/domain/cdcomment/controller/CdCommentController.java
+++ b/roome/src/main/java/com/roome/domain/cdcomment/controller/CdCommentController.java
@@ -4,6 +4,7 @@ import com.roome.domain.cdcomment.dto.CdCommentCreateRequest;
 import com.roome.domain.cdcomment.dto.CdCommentListResponse;
 import com.roome.domain.cdcomment.dto.CdCommentResponse;
 import com.roome.domain.cdcomment.service.CdCommentService;
+import com.roome.global.auth.AuthenticatedUser;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,21 +13,22 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/my-cd")
 public class CdCommentController {
 
   private final CdCommentService cdCommentService;
 
-  @PostMapping("/api/my-cd/{myCdId}/comment")
+  @PostMapping("/{myCdId}/comment")
   public ResponseEntity<CdCommentResponse> create(
+      @AuthenticatedUser Long userId,
       @PathVariable Long myCdId,
       @RequestBody @Valid CdCommentCreateRequest request
   ) {
-    Long userId = 1L; // 1주차에서는 임시로 userId = 1L 고정
     CdCommentResponse response = cdCommentService.addComment(userId, myCdId, request);
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping("/api/my-cd/{myCdId}/comments")
+  @GetMapping("/{myCdId}/comments")
   public ResponseEntity<CdCommentListResponse> getComments(
       @PathVariable Long myCdId,
       @RequestParam(value = "page", required = false, defaultValue = "0") int page,
@@ -36,7 +38,7 @@ public class CdCommentController {
     return ResponseEntity.ok(response);
   }
 
-  @GetMapping("/api/my-cd/{myCdId}/comments/search")
+  @GetMapping("/{myCdId}/comments/search")
   public ResponseEntity<CdCommentListResponse> searchComments(
       @PathVariable Long myCdId,
       @RequestParam("query") String keyword,
@@ -47,16 +49,21 @@ public class CdCommentController {
     return ResponseEntity.ok(response);
   }
 
-  @DeleteMapping("/api/my-cd/comments/{commentId}")
-  public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
-    cdCommentService.deleteComment(commentId);
+  @DeleteMapping("/comments/{commentId}")
+  public ResponseEntity<Void> deleteComment(
+      @AuthenticatedUser Long userId,
+      @PathVariable Long commentId
+  ) {
+    cdCommentService.deleteComment(userId, commentId);
     return ResponseEntity.noContent().build();
   }
 
-  @DeleteMapping("/api/my-cd/comments")
-  public ResponseEntity<Void> deleteMultipleComments(@RequestParam List<Long> commentIds) {
-    cdCommentService.deleteMultipleComments(commentIds);
+  @DeleteMapping("/comments")
+  public ResponseEntity<Void> deleteMultipleComments(
+      @AuthenticatedUser Long userId,
+      @RequestParam List<Long> commentIds
+  ) {
+    cdCommentService.deleteMultipleComments(userId, commentIds);
     return ResponseEntity.noContent().build();
   }
-
 }

--- a/roome/src/main/java/com/roome/domain/cdcomment/service/CdCommentService.java
+++ b/roome/src/main/java/com/roome/domain/cdcomment/service/CdCommentService.java
@@ -13,6 +13,7 @@ import com.roome.domain.mycd.exception.MyCdNotFoundException;
 import com.roome.domain.mycd.repository.MyCdRepository;
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
+import com.roome.global.exception.UnauthorizedException;
 import com.roome.global.jwt.exception.UserNotFoundException;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -111,19 +112,29 @@ public class CdCommentService {
   }
 
   @Transactional
-  public void deleteComment(Long commentId) {
+  public void deleteComment(Long userId, Long commentId) {
     CdComment comment = cdCommentRepository.findById(commentId)
         .orElseThrow(CdCommentNotFoundException::new);
+
+    if (!comment.getUser().getId().equals(userId)) {
+      throw new UnauthorizedException();
+    }
 
     cdCommentRepository.delete(comment);
   }
 
   @Transactional
-  public void deleteMultipleComments(List<Long> commentIds) {
+  public void deleteMultipleComments(Long userId, List<Long> commentIds) {
     List<CdComment> comments = cdCommentRepository.findAllById(commentIds);
 
     if (comments.isEmpty()) {
       throw new CdCommentNotFoundException();
+    }
+
+    for (CdComment comment : comments) {
+      if (!comment.getUser().getId().equals(userId)) {
+        throw new UnauthorizedException();
+      }
     }
 
     cdCommentRepository.deleteAll(comments);

--- a/roome/src/main/java/com/roome/global/exception/UnauthorizedException.java
+++ b/roome/src/main/java/com/roome/global/exception/UnauthorizedException.java
@@ -1,6 +1,7 @@
 package com.roome.global.exception;
 
-public class UnauthorizedException extends ControllerException {
+public class UnauthorizedException extends BusinessException {
+
   public UnauthorizedException() {
     super(ErrorCode.UNAUTHORIZED_ACCESS);
   }

--- a/roome/src/test/java/com/roome/domain/cdcomment/controller/CdCommentControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/cdcomment/controller/CdCommentControllerTest.java
@@ -5,6 +5,7 @@ import com.roome.domain.cdcomment.dto.CdCommentCreateRequest;
 import com.roome.domain.cdcomment.dto.CdCommentListResponse;
 import com.roome.domain.cdcomment.dto.CdCommentResponse;
 import com.roome.domain.cdcomment.service.CdCommentService;
+import com.roome.global.auth.AuthenticatedUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
@@ -39,13 +40,13 @@ class CdCommentControllerTest {
   private ObjectMapper objectMapper;
 
   @DisplayName("댓글 추가 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void addComment_Success() throws Exception {
     CdCommentCreateRequest request = createCdCommentCreateRequest();
     CdCommentResponse response = createCdCommentResponse(1L, request);
 
-    BDDMockito.given(cdCommentService.addComment(any(Long.class), any(Long.class), any(CdCommentCreateRequest.class)))
+    BDDMockito.given(cdCommentService.addComment(eq(1L), any(Long.class), any(CdCommentCreateRequest.class)))
         .willReturn(response);
 
     mockMvc.perform(post("/api/my-cd/1/comment")
@@ -97,18 +98,18 @@ class CdCommentControllerTest {
   }
 
   @DisplayName("CD 댓글 삭제 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void deleteComment_Success() throws Exception {
     mockMvc.perform(delete("/api/my-cd/comments/1")
             .with(csrf()))
         .andExpect(status().isNoContent());
 
-    BDDMockito.verify(cdCommentService).deleteComment(1L);
+    BDDMockito.verify(cdCommentService).deleteComment(eq(1L), eq(1L));
   }
 
   @DisplayName("CD 댓글 다중 삭제 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   @Test
   void deleteMultipleComments_Success() throws Exception {
     mockMvc.perform(delete("/api/my-cd/comments")
@@ -116,7 +117,7 @@ class CdCommentControllerTest {
             .with(csrf()))
         .andExpect(status().isNoContent());
 
-    BDDMockito.verify(cdCommentService).deleteMultipleComments(List.of(1L, 2L, 3L));
+    BDDMockito.verify(cdCommentService).deleteMultipleComments(eq(1L), eq(List.of(1L, 2L, 3L)));
   }
 
   private CdCommentCreateRequest createCdCommentCreateRequest() {


### PR DESCRIPTION
## 📌 CdCommentController에 @AuthenticatedUser 적용 및 댓글 삭제 권한 검증 추가

### ✅ PR 설명
CdCommentController에서 @AuthenticatedUser를 적용하여 userId를 자동으로 주입하도록 수정하고, 댓글 삭제 시 작성자만 삭제할 수 있도록 권한 검증을 추가했습니다.

### 🏗 작업 내용
- CdCommentController에서 @RequestParam 을 제거하고 @AuthenticatedUser 적용
- 댓글 삭제 시 본인 댓글인지 검증 후 삭제 (UnauthorizedException 추가)
- CdCommentControllerTest 및 CdCommentServiceTest 수정
- WithMockUser(username = "1")을 추가하여 userId 자동 주입
- 댓글 삭제 시 UnauthorizedException 발생 여부 테스트 추가

### 📸 테스트 결과 (선택)
> <img width="885" alt="스크린샷 2025-02-26 15 59 36" src="https://github.com/user-attachments/assets/69fbb31a-4b1a-4792-abc7-c6864a281380" />

### 🔗 관련 이슈 (선택)
> #159 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
