### PR TITLE
feat: CdTemplateController에 @AuthenticatedUser 적용 및 테스트 코드 수정

### DIFF
--- a/roome/src/main/java/com/roome/domain/cdtemplate/controller/CdTemplateController.java
+++ b/roome/src/main/java/com/roome/domain/cdtemplate/controller/CdTemplateController.java
@@ -3,6 +3,7 @@ package com.roome.domain.cdtemplate.controller;
 import com.roome.domain.cdtemplate.dto.CdTemplateRequest;
 import com.roome.domain.cdtemplate.dto.CdTemplateResponse;
 import com.roome.domain.cdtemplate.service.CdTemplateService;
+import com.roome.global.auth.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,8 +17,8 @@ public class CdTemplateController {
 
   @PostMapping
   public ResponseEntity<CdTemplateResponse> createTemplate(
+      @AuthenticatedUser Long userId,
       @PathVariable Long myCdId,
-      @RequestParam Long userId,
       @RequestBody CdTemplateRequest request
   ) {
     return ResponseEntity.ok(cdTemplateService.createTemplate(myCdId, userId, request));
@@ -30,15 +31,18 @@ public class CdTemplateController {
 
   @PatchMapping
   public ResponseEntity<CdTemplateResponse> updateTemplate(
+      @AuthenticatedUser Long userId,
       @PathVariable Long myCdId,
-      @RequestParam Long userId,
       @RequestBody CdTemplateRequest request
   ) {
     return ResponseEntity.ok(cdTemplateService.updateTemplate(myCdId, userId, request));
   }
 
   @DeleteMapping
-  public ResponseEntity<Void> deleteTemplate(@PathVariable Long myCdId, @RequestParam Long userId) {
+  public ResponseEntity<Void> deleteTemplate(
+      @AuthenticatedUser Long userId,
+      @PathVariable Long myCdId
+  ) {
     cdTemplateService.deleteTemplate(myCdId, userId);
     return ResponseEntity.noContent().build();
   }

--- a/roome/src/test/java/com/roome/domain/cdtemplate/controller/CdTemplateControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/cdtemplate/controller/CdTemplateControllerTest.java
@@ -37,7 +37,7 @@ class CdTemplateControllerTest {
 
   @Test
   @DisplayName("CD 템플릿 생성 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   void createTemplate_Success() throws Exception {
     CdTemplateRequest request = createCdTemplateRequest();
     CdTemplateResponse response = createCdTemplateResponse(1L, request);
@@ -46,7 +46,6 @@ class CdTemplateControllerTest {
         .willReturn(response);
 
     mockMvc.perform(post("/api/my-cd/1/template")
-            .param("userId", "1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
             .with(csrf()))
@@ -57,11 +56,12 @@ class CdTemplateControllerTest {
 
   @Test
   @DisplayName("CD 템플릿 조회 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   void getTemplate_Success() throws Exception {
     CdTemplateResponse response = createCdTemplateResponse(1L, createCdTemplateRequest());
 
-    BDDMockito.given(cdTemplateService.getTemplate(eq(1L))).willReturn(response);
+    BDDMockito.given(cdTemplateService.getTemplate(eq(1L)))
+        .willReturn(response);
 
     mockMvc.perform(get("/api/my-cd/1/template")
             .accept(MediaType.APPLICATION_JSON))
@@ -71,7 +71,7 @@ class CdTemplateControllerTest {
 
   @Test
   @DisplayName("CD 템플릿 수정 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   void updateTemplate_Success() throws Exception {
     CdTemplateRequest request = createCdTemplateRequest();
     CdTemplateResponse response = createCdTemplateResponse(1L, request);
@@ -80,7 +80,6 @@ class CdTemplateControllerTest {
         .willReturn(response);
 
     mockMvc.perform(patch("/api/my-cd/1/template")
-            .param("userId", "1")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request))
             .with(csrf()))
@@ -90,10 +89,9 @@ class CdTemplateControllerTest {
 
   @Test
   @DisplayName("CD 템플릿 삭제 성공")
-  @WithMockUser
+  @WithMockUser(username = "1")
   void deleteTemplate_Success() throws Exception {
     mockMvc.perform(delete("/api/my-cd/1/template")
-            .param("userId", "1")
             .with(csrf()))
         .andExpect(status().isNoContent());
 


### PR DESCRIPTION
## 📌 CdTemplateController 인증 적용 및 테스트 코드 수정

### ✅ PR 설명
- CdTemplateController에 인증 기능을 적용하고, 관련 테스트 코드를 수정하였습니다.

### 🏗 작업 내용
- @AuthenticatedUser를 적용하여 userId 자동 주입
- 템플릿 생성, 수정, 삭제 API에 인증 적용
- CdTemplateControllerTest에서 userId 관련 테스트 수정 및 보완

### 📸 테스트 결과 (선택)
> 
<img width="676" alt="스크린샷 2025-02-26 17 33 23" src="https://github.com/user-attachments/assets/d7585cd4-c2d1-4862-8468-2057874bb041" />


### 🔗 관련 이슈 (선택)
> #161 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
