### PR TITLE
Feat: OAuth2 로그인 리다이렉트 설정 변경 및 SecurityConfig 기본 설정 추가 

### DIFF
--- a/roome/src/main/java/com/roome/global/config/SecurityConfig.java
+++ b/roome/src/main/java/com/roome/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.roome.global.jwt.handler.OAuth2AuthenticationSuccessHandler;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.service.RedisService;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,10 +19,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Configuration
@@ -61,20 +59,21 @@ public class SecurityConfig {
             )
             .successHandler(oAuth2AuthenticationSuccessHandler)
             .failureHandler(oAuth2AuthenticationFailureHandler)
+            .defaultSuccessUrl("/oauth2/success", true)
         )
 
         // 접근 제어 설정
         .authorizeHttpRequests((auth) -> auth
-                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                .requestMatchers(
-                    "/api/auth/**",
-                    "/error",
-                    "/v3/api-docs/**",
-                    "/swagger-ui/**",
-                    "/swagger-ui.html",
-                    "/mock/**"
-                ).permitAll()
-                .anyRequest().authenticated()
+            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+            .requestMatchers(
+                "/api/auth/**",
+                "/error",
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/mock/**"
+            ).permitAll()
+            .anyRequest().authenticated()
         )
 
         // 예외 처리

--- a/roome/src/main/java/com/roome/global/jwt/controller/ReissueController.java
+++ b/roome/src/main/java/com/roome/global/jwt/controller/ReissueController.java
@@ -1,11 +1,13 @@
 package com.roome.global.jwt.controller;
 
 import com.roome.global.jwt.dto.JwtToken;
+import com.roome.global.jwt.dto.TokenReissueRequest;
 import com.roome.global.jwt.exception.InvalidRefreshTokenException;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.jwt.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @Slf4j
 @RestController
 @RequestMapping("/api/auth")
@@ -23,48 +23,48 @@ import java.util.Map;
 @Tag(name = "Token", description = "토큰 관련 API")
 public class ReissueController {
 
-    private final TokenService tokenService;
-    private final JwtTokenProvider jwtTokenProvider;
+  private final TokenService tokenService;
+  private final JwtTokenProvider jwtTokenProvider;
 
-    @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
-    @PostMapping("/reissue-token")
-    public ResponseEntity<?> reissueToken(@RequestBody Map<String, String> request) {
-        try {
-            String refreshToken = request.get("refreshToken");
+  @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
+  @PostMapping("/reissue-token")
+  public ResponseEntity<?> reissueToken(@RequestBody TokenReissueRequest request) {
+    try {
+      String refreshToken = request.getRefreshToken();
 
-            // 리프레시 토큰 검증
-            if (refreshToken == null || refreshToken.isBlank()) {
-                return ResponseEntity.badRequest()
-                        .body(Map.of("message", "리프레시 토큰이 필요합니다."));
-            }
+      // 리프레시 토큰 검증
+      if (refreshToken == null || refreshToken.isBlank()) {
+        return ResponseEntity.badRequest()
+            .body(Map.of("message", "리프레시 토큰이 필요합니다."));
+      }
 
-            // 리프레시 토큰이 유효한지 확인
-            if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
-                return ResponseEntity.badRequest()
-                        .body(Map.of("message", "유효하지 않은 리프레시 토큰입니다."));
-            }
+      // 리프레시 토큰이 유효한지 확인
+      if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+        return ResponseEntity.badRequest()
+            .body(Map.of("message", "유효하지 않은 리프레시 토큰입니다."));
+      }
 
-            // 새로운 토큰 발급
-            JwtToken newToken = tokenService.reissueToken(refreshToken);
+      // 새로운 토큰 발급
+      JwtToken newToken = tokenService.reissueToken(refreshToken);
 
-            return ResponseEntity.ok(createTokenResponse(newToken));
-        } catch (InvalidRefreshTokenException e) {
-            log.warn("유효하지 않은 리프레시 토큰: {}", e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(Map.of("message", e.getMessage()));
-        } catch (Exception e) {
-            log.error("토큰 재발급 중 오류 발생: ", e);
-            return ResponseEntity.internalServerError()
-                    .body(Map.of("message", "토큰 재발급 중 오류가 발생했습니다."));
-        }
+      return ResponseEntity.ok(createTokenResponse(newToken));
+    } catch (InvalidRefreshTokenException e) {
+      log.warn("유효하지 않은 리프레시 토큰: {}", e.getMessage());
+      return ResponseEntity.badRequest()
+          .body(Map.of("message", e.getMessage()));
+    } catch (Exception e) {
+      log.error("토큰 재발급 중 오류 발생: ", e);
+      return ResponseEntity.internalServerError()
+          .body(Map.of("message", "토큰 재발급 중 오류가 발생했습니다."));
     }
+  }
 
-    private Map<String, Object> createTokenResponse(JwtToken token) {
-        return Map.of(
-                "accessToken", token.getAccessToken(),
-                "refreshToken", token.getRefreshToken(),
-                "tokenType", token.getGrantType(),
-                "expiresIn", jwtTokenProvider.getAccessTokenExpirationTime() / 1000
-        );
-    }
+  private Map<String, Object> createTokenResponse(JwtToken token) {
+    return Map.of(
+        "accessToken", token.getAccessToken(),
+        "refreshToken", token.getRefreshToken(),
+        "tokenType", token.getGrantType(),
+        "expiresIn", jwtTokenProvider.getAccessTokenExpirationTime() / 1000
+    );
+  }
 }

--- a/roome/src/main/java/com/roome/global/jwt/dto/TokenReissueRequest.java
+++ b/roome/src/main/java/com/roome/global/jwt/dto/TokenReissueRequest.java
@@ -1,0 +1,11 @@
+package com.roome.global.jwt.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TokenReissueRequest {
+
+  private String refreshToken;
+}

--- a/roome/src/main/resources/application.yml
+++ b/roome/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
             client-name: google
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: http://localhost:5173/oauth/callback/google
+            redirect-uri: "{baseUrl}/oauth/callback/{registrationId}"
             authorization-grant-type: authorization_code
             scope:
               - email
@@ -20,7 +20,7 @@ spring:
             client-name: naver
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
-            redirect-uri: http://localhost:5173/oauth/callback/naver
+            redirect-uri: "{baseUrl}/oauth/callback/{registrationId}"
             authorization-grant-type: authorization_code
             scope:
               - name
@@ -30,7 +30,7 @@ spring:
             client-name: Kakao
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: http://localhost:5173/oauth/callback/kakao
+            redirect-uri: "{baseUrl}/oauth/callback/{registrationId}"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope:


### PR DESCRIPTION
## 📌 Feat: OAuth2 로그인 리다이렉트 설정 변경 및 SecurityConfig 기본 설정 추가 

### ✅ PR 설명
SecurityConfig에 defaultSuccessUrl를 추가하여 success handler 실행

### 🏗 작업 내용
- [ ] SecurityConfig에 defaultSuccessUrl("/oauth2/success", true) 추가  
- [ ] OAuth2 redirect-uri를 {baseUrl}/oauth/callback/{registrationId} 형식으로 변경  
- [ ] 기존 리디렉트 설정을 통일하여 provider 구분 자동화 

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
