### PR TITLE
Fix: OAuth2 로그인 및 토큰 관련 이슈 해결

### DIFF
--- a/roome/src/main/java/com/roome/global/jwt/controller/ReissueController.java
+++ b/roome/src/main/java/com/roome/global/jwt/controller/ReissueController.java
@@ -1,13 +1,14 @@
 package com.roome.global.jwt.controller;
 
+import com.roome.domain.auth.dto.response.MessageResponse;
 import com.roome.global.jwt.dto.JwtToken;
 import com.roome.global.jwt.dto.TokenReissueRequest;
+import com.roome.global.jwt.dto.TokenResponse;
 import com.roome.global.jwt.exception.InvalidRefreshTokenException;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.jwt.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -35,13 +36,13 @@ public class ReissueController {
       // 리프레시 토큰 검증
       if (refreshToken == null || refreshToken.isBlank()) {
         return ResponseEntity.badRequest()
-            .body(Map.of("message", "리프레시 토큰이 필요합니다."));
+            .body(new MessageResponse("리프레시 토큰이 필요합니다."));
       }
 
       // 리프레시 토큰이 유효한지 확인
       if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
         return ResponseEntity.badRequest()
-            .body(Map.of("message", "유효하지 않은 리프레시 토큰입니다."));
+            .body(new MessageResponse("유효하지 않은 리프레시 토큰입니다."));
       }
 
       // 새로운 토큰 발급
@@ -51,20 +52,20 @@ public class ReissueController {
     } catch (InvalidRefreshTokenException e) {
       log.warn("유효하지 않은 리프레시 토큰: {}", e.getMessage());
       return ResponseEntity.badRequest()
-          .body(Map.of("message", e.getMessage()));
+          .body(new MessageResponse(e.getMessage()));
     } catch (Exception e) {
       log.error("토큰 재발급 중 오류 발생: ", e);
       return ResponseEntity.internalServerError()
-          .body(Map.of("message", "토큰 재발급 중 오류가 발생했습니다."));
+          .body(new MessageResponse("토큰 재발급 중 오류가 발생했습니다."));
     }
   }
 
-  private Map<String, Object> createTokenResponse(JwtToken token) {
-    return Map.of(
-        "accessToken", token.getAccessToken(),
-        "refreshToken", token.getRefreshToken(),
-        "tokenType", token.getGrantType(),
-        "expiresIn", jwtTokenProvider.getAccessTokenExpirationTime() / 1000
-    );
+  private TokenResponse createTokenResponse(JwtToken token) {
+    return TokenResponse.builder()
+        .accessToken(token.getAccessToken())
+        .refreshToken(token.getRefreshToken())
+        .tokenType(token.getGrantType())
+        .expiresIn(jwtTokenProvider.getAccessTokenExpirationTime() / 1000)
+        .build();
   }
 }

--- a/roome/src/main/java/com/roome/global/jwt/dto/TokenResponse.java
+++ b/roome/src/main/java/com/roome/global/jwt/dto/TokenResponse.java
@@ -1,0 +1,18 @@
+package com.roome.global.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+
+  private String accessToken;
+  private String refreshToken;
+  private String tokenType;
+  private long expiresIn;
+}

--- a/roome/src/main/resources/application.yml
+++ b/roome/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
             client-name: google
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}/oauth/callback/{registrationId}"
+            redirect-uri: https://desqb38rc2v50.cloudfront.net/oauth/callback/google
             authorization-grant-type: authorization_code
             scope:
               - email

--- a/roome/src/test/java/com/roome/global/jwt/handler/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/roome/src/test/java/com/roome/global/jwt/handler/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,5 +1,15 @@
 package com.roome.global.jwt.handler;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.roome.domain.auth.security.OAuth2UserPrincipal;
 import com.roome.domain.user.entity.Provider;
 import com.roome.domain.user.entity.Status;
@@ -9,6 +19,8 @@ import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.service.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,89 +35,78 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.io.IOException;
-import java.time.LocalDateTime;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class OAuth2AuthenticationSuccessHandlerTest {
 
-    @InjectMocks
-    private OAuth2AuthenticationSuccessHandler successHandler;
+  @InjectMocks
+  private OAuth2AuthenticationSuccessHandler successHandler;
 
-    @Mock
-    private JwtTokenProvider jwtTokenProvider;
+  @Mock
+  private JwtTokenProvider jwtTokenProvider;
 
-    @Mock
-    private RedisService redisService;
+  @Mock
+  private RedisService redisService;
 
-    @Mock
-    private RedirectStrategy redirectStrategy;
+  @Mock
+  private RedirectStrategy redirectStrategy;
 
-    @BeforeEach
-    void setUp() {
-        // 테스트를 위한 redirectUri 설정
-        ReflectionTestUtils.setField(successHandler, "redirectUri", "http://localhost:5173/oauth/callback");
-        successHandler.setRedirectStrategy(redirectStrategy);
-    }
+  @BeforeEach
+  void setUp() {
+    // 테스트를 위한 redirectUri 설정
+    ReflectionTestUtils.setField(successHandler, "redirectUri",
+        "http://localhost:5173/oauth/callback");
+    successHandler.setRedirectStrategy(redirectStrategy);
+  }
 
-    @Test
-    @DisplayName("인증 성공 시 JWT 토큰이 발급되고 Redis에 저장되며, 프론트엔드로 리다이렉트된다")
-    void onAuthenticationSuccess_GeneratesTokenAndRedirects() throws IOException {
-        // Given
-        HttpServletRequest request = new MockHttpServletRequest();
-        HttpServletResponse response = new MockHttpServletResponse();
+  @Test
+  @DisplayName("인증 성공 시 JWT 토큰이 발급되고 Redis에 저장되며, 프론트엔드로 리다이렉트된다")
+  void onAuthenticationSuccess_GeneratesTokenAndRedirects() throws IOException {
+    // Given
+    HttpServletRequest request = new MockHttpServletRequest();
+    HttpServletResponse response = new MockHttpServletResponse();
 
-        User user = User.builder()
-                .id(1L)
-                .email("test@example.com")
-                .name("Test User")
-                .nickname("testuser")
-                .provider(Provider.KAKAO)
-                .providerId("12345")
-                .status(Status.OFFLINE)
-                .lastLogin(LocalDateTime.now())
-                .build();
+    User user = User.builder()
+        .id(1L)
+        .email("test@example.com")
+        .name("Test User")
+        .nickname("testuser")
+        .provider(Provider.KAKAO)
+        .providerId("12345")
+        .status(Status.OFFLINE)
+        .lastLogin(LocalDateTime.now())
+        .build();
 
-        OAuth2UserPrincipal oAuth2UserPrincipal = mock(OAuth2UserPrincipal.class);
-        when(oAuth2UserPrincipal.getUser()).thenReturn(user);
+    OAuth2UserPrincipal oAuth2UserPrincipal = mock(OAuth2UserPrincipal.class);
+    when(oAuth2UserPrincipal.getUser()).thenReturn(user);
 
-        Authentication authentication = new TestingAuthenticationToken(oAuth2UserPrincipal, null);
+    Authentication authentication = new TestingAuthenticationToken(oAuth2UserPrincipal, null);
 
-        JwtToken jwtToken = JwtToken.builder()
-                .grantType("Bearer")
-                .accessToken("test-access-token")
-                .refreshToken("test-refresh-token")
-                .build();
+    JwtToken jwtToken = JwtToken.builder()
+        .grantType("Bearer")
+        .accessToken("test-access-token")
+        .refreshToken("test-refresh-token")
+        .build();
 
-        // Mocking
-        when(jwtTokenProvider.createToken(anyString())).thenReturn(jwtToken);
-        doNothing().when(redisService).saveRefreshToken(anyString(), anyString(), anyLong());
-        doNothing().when(redirectStrategy).sendRedirect(any(), any(), anyString());
+    // Mocking
+    when(jwtTokenProvider.createToken(anyString())).thenReturn(jwtToken);
+    doNothing().when(redisService).saveRefreshToken(anyString(), anyString(), anyLong());
+    doNothing().when(redirectStrategy).sendRedirect(any(), any(), anyString());
 
-        // When
-        successHandler.onAuthenticationSuccess(request, response, authentication);
+    // When
+    successHandler.onAuthenticationSuccess(request, response, authentication);
 
-        // Then
-        verify(jwtTokenProvider).createToken(user.getId().toString());
-        verify(redisService).saveRefreshToken(
-                eq(user.getId().toString()),
-                eq(jwtToken.getRefreshToken()),
-                anyLong()
-        );
+    // Then
+    verify(jwtTokenProvider).createToken(user.getId().toString());
+    verify(redisService).saveRefreshToken(
+        eq(user.getId().toString()),
+        eq(jwtToken.getRefreshToken()),
+        anyLong()
+    );
 
-        // 리다이렉트 검증 - URL에 액세스 토큰과 사용자 ID가 포함되어야 함
-        verify(redirectStrategy).sendRedirect(
-                eq(request),
-                eq(response),
-                contains("accessToken=test-access-token")
-        );
-        verify(redirectStrategy).sendRedirect(
-                eq(request),
-                eq(response),
-                contains("userId=1")
-        );
-    }
+    verify(redirectStrategy).sendRedirect(
+        eq(request),
+        eq(response),
+        contains("accessToken=test-access-token")
+    );
+  }
 }


### PR DESCRIPTION
## 📌 Fix: OAuth2 로그인 및 토큰 관련 이슈 해결

### ✅ PR 설명
OAuth2 로그인 리디렉션 문제와 토큰 관련 여러 이슈를 해결하였습니다. 코드 품질 향상과 에러 처리를 개선했습니다.

### 🏗 작업 내용
- [ ] Google OAuth2 리디렉트 URI를 CloudFront 도메인으로 변경
- [ ] OAuth2 성공 핸들러 테스트에서 userId 검증 로직 제거
- [ ] 토큰 응답을 위한 DTO 클래스(TokenResponse, ErrorResponse) 추가
- [ ] 토큰 재발급 API의 예외 처리를 세분화하여 구체적인 오류 메시지 제공
- [ ] 토큰 재발급 컨트롤러의 유효성 검증 로직 개선 및 NullPointerException 방지

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
