### PR TITLE
Feat: MyCd 목록 조회 시 검색 기능 및 총 개수 반환 기능 추가

### DIFF
--- a/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
@@ -31,10 +31,11 @@ public class MyCdController {
   @GetMapping
   public ResponseEntity<MyCdListResponse> getMyCdList(
       @AuthenticatedUser Long userId,
-      @RequestParam(value = "cursor", required = false, defaultValue = "0") Long cursor,  // ✅ 기본값 0L 설정
-      @RequestParam(value = "size", defaultValue = "10") int size
+      @RequestParam(value = "cursor", required = false) Long cursor,
+      @RequestParam(value = "size", defaultValue = "10") int size,
+      @RequestParam(value = "keyword", required = false) String keyword
   ) {
-    return ResponseEntity.ok(myCdService.getMyCdList(userId, cursor, size));
+    return ResponseEntity.ok(myCdService.getMyCdList(userId, keyword, cursor, size));
   }
 
   @GetMapping("/{myCdId}")

--- a/roome/src/main/java/com/roome/domain/mycd/dto/MyCdListResponse.java
+++ b/roome/src/main/java/com/roome/domain/mycd/dto/MyCdListResponse.java
@@ -10,19 +10,21 @@ import java.util.stream.Collectors;
 public class MyCdListResponse {
   private final List<MyCdResponse> data;
   private final Long nextCursor;  // 다음 페이지의 커서 (무한 스크롤)
+  private final long totalCount;  // 전체 개수 추가
 
-  public MyCdListResponse(List<MyCdResponse> data, Long nextCursor) {
+  public MyCdListResponse(List<MyCdResponse> data, Long nextCursor, long totalCount) {
     this.data = data;
     this.nextCursor = nextCursor;
+    this.totalCount = totalCount;
   }
 
-  public static MyCdListResponse fromEntities(List<MyCd> myCds) {
+  public static MyCdListResponse fromEntities(List<MyCd> myCds, long totalCount) {
     List<MyCdResponse> responses = myCds.stream()
         .map(MyCdResponse::fromEntity)
         .collect(Collectors.toList());
 
     Long nextCursor = myCds.isEmpty() ? null : myCds.get(myCds.size() - 1).getId();
 
-    return new MyCdListResponse(responses, nextCursor);
+    return new MyCdListResponse(responses, nextCursor, totalCount);
   }
 }

--- a/roome/src/main/java/com/roome/domain/mycd/repository/MyCdRepository.java
+++ b/roome/src/main/java/com/roome/domain/mycd/repository/MyCdRepository.java
@@ -23,6 +23,24 @@ public interface MyCdRepository extends JpaRepository<MyCd, Long> {
 
   List<MyCd> findByUserIdAndIdGreaterThanOrderByIdAsc(Long userId, Long id, Pageable pageable);
 
+  long countByUserId(Long userId); // 사용자의 전체 MyCd 개수 반환
+
+  // 키워드 기반 검색 (CD 제목 또는 가수명)
+  @Query("SELECT mc FROM MyCd mc JOIN mc.cd c " +
+      "WHERE mc.user.id = :userId " +
+      "AND (LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+      "OR LOWER(c.artist) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+  List<MyCd> searchByUserIdAndKeyword(@Param("userId") Long userId,
+      @Param("keyword") String keyword,
+      Pageable pageable);
+
+  // 검색된 결과의 전체 개수 반환
+  @Query("SELECT COUNT(mc) FROM MyCd mc JOIN mc.cd c " +
+      "WHERE mc.user.id = :userId " +
+      "AND (LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+      "OR LOWER(c.artist) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+  long countByUserIdAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
+
   @Modifying
   @Query("DELETE FROM MyCd mc WHERE mc.user.id = :userId AND mc.id IN (:ids)")
   void deleteByUserIdAndIds(@Param("userId") Long userId, @Param("ids") List<Long> ids);

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -90,11 +90,7 @@ public class MyCdService {
     long totalCount;
 
     if (keyword != null && !keyword.isBlank()) {
-      if (cursor == null) {
-        myCds = myCdRepository.searchByUserIdAndKeyword(userId, keyword, PageRequest.of(0, size));
-      } else {
-        myCds = myCdRepository.searchByUserIdAndKeyword(userId, keyword, PageRequest.of(0, size));
-      }
+      myCds = myCdRepository.searchByUserIdAndKeyword(userId, keyword, PageRequest.of(0, size));
       totalCount = myCdRepository.countByUserIdAndKeyword(userId, keyword);
     } else {
       if (cursor == null) {
@@ -104,6 +100,7 @@ public class MyCdService {
       }
       totalCount = myCdRepository.countByUserId(userId);
     }
+
 
     if (myCds.isEmpty()) {
       throw new MyCdListEmptyException();

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -83,21 +83,33 @@ public class MyCdService {
     return MyCdResponse.fromEntity(myCd);
   }
 
-  public MyCdListResponse getMyCdList(Long userId, Long cursor, int size) {
+  public MyCdListResponse getMyCdList(Long userId, String keyword, Long cursor, int size) {
     validateUser(userId);
 
     List<MyCd> myCds;
-    if (cursor == null) {
-      myCds = myCdRepository.findByUserIdOrderByIdAsc(userId, PageRequest.of(0, size));
+    long totalCount;
+
+    if (keyword != null && !keyword.isBlank()) {
+      if (cursor == null) {
+        myCds = myCdRepository.searchByUserIdAndKeyword(userId, keyword, PageRequest.of(0, size));
+      } else {
+        myCds = myCdRepository.searchByUserIdAndKeyword(userId, keyword, PageRequest.of(0, size));
+      }
+      totalCount = myCdRepository.countByUserIdAndKeyword(userId, keyword);
     } else {
-      myCds = myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor, PageRequest.of(0, size));
+      if (cursor == null) {
+        myCds = myCdRepository.findByUserIdOrderByIdAsc(userId, PageRequest.of(0, size));
+      } else {
+        myCds = myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor, PageRequest.of(0, size));
+      }
+      totalCount = myCdRepository.countByUserId(userId);
     }
 
     if (myCds.isEmpty()) {
       throw new MyCdListEmptyException();
     }
 
-    return MyCdListResponse.fromEntities(myCds);
+    return MyCdListResponse.fromEntities(myCds, totalCount);
   }
 
   public MyCdResponse getMyCd(Long userId, Long myCdId) {


### PR DESCRIPTION
## 📌 PR 제목 feat: MyCd 목록 조회 시 검색 기능 및 총 개수 반환 기능 추가

### ✅ PR 설명
MyCd 목록 조회 시 CD 제목 또는 가수명(keyword)으로 검색하는 기능을 추가하고, 검색된 결과의 총 개수를 반환하는 기능을 구현하였습니다.
또한, 테스트 코드 추가 및 커버리지 개선을 진행했습니다.

### 🏗 작업 내용
- MyCd 목록 조회 시 키워드 검색 기능 추가
- 검색된 결과의 전체 개수 반환 기능 추가
- 테스트 코드 추가 및 커버리지 개선

### 📸 테스트 결과 (선택)
> <img width="632" alt="스크린샷 2025-02-28 11 22 15" src="https://github.com/user-attachments/assets/b2e723e5-aba8-47b9-946a-be83ebc63dcc" />
<img width="816" alt="스크린샷 2025-02-28 12 00 10" src="https://github.com/user-attachments/assets/f9556e45-5b91-4412-886a-43d801d198a5" />


### 🔗 관련 이슈 (선택)
> #187 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
