### PR TITLE
Refactor: user, room 엔티티 수정 및 getOrCreateRoomByUserId 삭제

### DIFF
--- a/roome/src/main/java/com/roome/domain/auth/service/CustomOAuth2UserService.java
+++ b/roome/src/main/java/com/roome/domain/auth/service/CustomOAuth2UserService.java
@@ -52,16 +52,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       // 기존 사용자 확인 또는 생성
       User user = updateOrCreateUser(oAuth2Response);
 
-      // 첫 로그인 시 방 자동 생성
-      if (user.getLastLogin() == null) {
-        try {
-          roomService.getOrCreateRoomByUserId(user.getId());
-          log.info("사용자 {}의 방이 확인/생성되었습니다.", user.getId());
-        } catch (Exception e) {
-          log.error("방 확인/생성 중 오류: {}", e.getMessage(), e);
-        }
-      }
-
       // 마지막 로그인 시간 갱신
       user.updateLastLogin();
       if (user.getId() != null) {

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -4,11 +4,26 @@ import com.roome.domain.point.entity.Point;
 import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.exception.RoomAuthorizationException;
 import com.roome.global.entity.BaseTimeEntity;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -61,6 +76,7 @@ public class User extends BaseTimeEntity {
   private String refreshToken;
 
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @PrimaryKeyJoinColumn
   private Room room;
 
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -68,11 +84,12 @@ public class User extends BaseTimeEntity {
 
   @PrePersist
   public void prePersist() {
-    if (this.lastLogin == null) {
-      this.lastLogin = LocalDateTime.now();
-    }
     if (this.point == null) {
       this.point = new Point(this, 0, 0, 0);
+    }
+
+    if (this.room == null) {
+      this.room = Room.builder().user(this).build();
     }
   }
 


### PR DESCRIPTION
## 📌 Refactor: user, room 엔티티 수정 및 getOrCreateRoomByUserId 삭제

### ✅ PR 설명
user와 room 엔티티를 수정하여 userId와 roomId를 동일하게 설정하고, getOrCreateRoomByUserId 메서드를 삭제하여 불필요한 로직을 정리했습니다.


### 🏗 작업 내용
- [ ] user 엔티티에서 room 관계 수정 (@PrimaryKeyJoinColumn 추가)
- [ ] room 엔티티에서 userId를 roomId로 사용하도록 설정 (@MapsId 추가)
- [ ] getOrCreateRoomByUserId 메서드 삭제

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 기존 getOrCreateRoomByUserId를 사용하던 부분이 있다면 getRoomByUserId로 변경 필요
