### PR TITLE
Feat/#209 read cd comments all

### DIFF
--- a/roome/src/main/java/com/roome/domain/cdcomment/controller/CdCommentController.java
+++ b/roome/src/main/java/com/roome/domain/cdcomment/controller/CdCommentController.java
@@ -44,6 +44,15 @@ public class CdCommentController {
     return ResponseEntity.ok(response);
   }
 
+  @Operation(summary = "CD 전체 댓글 목록 조회", description = "특정 CD의 모든 댓글을 조회합니다.")
+  @GetMapping("/{myCdId}/comments/all")
+  public ResponseEntity<List<CdCommentResponse>> getAllComments(
+      @Parameter(description = "댓글을 조회할 CD의 ID") @PathVariable Long myCdId
+  ) {
+    List<CdCommentResponse> response = cdCommentService.getAllComments(myCdId);
+    return ResponseEntity.ok(response);
+  }
+
   @Operation(summary = "CD 댓글 검색", description = "특정 CD의 댓글 중 키워드를 포함하는 댓글을 검색합니다.")
   @GetMapping("/{myCdId}/comments/search")
   public ResponseEntity<CdCommentListResponse> searchComments(

--- a/roome/src/main/java/com/roome/domain/cdcomment/repository/CdCommentRepository.java
+++ b/roome/src/main/java/com/roome/domain/cdcomment/repository/CdCommentRepository.java
@@ -16,6 +16,8 @@ public interface CdCommentRepository extends JpaRepository<CdComment, Long> {
 
   Page<CdComment> findByMyCdId(Long myCdId, Pageable pageable);
 
+  List<CdComment> findByMyCdId(Long myCdId);
+
   @Query("SELECT c FROM CdComment c " + "WHERE c.myCd.id = :myCdId "
       + "AND (LOWER(c.content) LIKE LOWER(CONCAT('%', :keyword, '%')) "
       + "OR LOWER(c.user.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))")

--- a/roome/src/main/java/com/roome/domain/cdcomment/service/CdCommentService.java
+++ b/roome/src/main/java/com/roome/domain/cdcomment/service/CdCommentService.java
@@ -85,6 +85,26 @@ public class CdCommentService {
         commentPage.getTotalPages());
   }
 
+  public List<CdCommentResponse> getAllComments(Long myCdId) {
+    List<CdComment> comments = cdCommentRepository.findByMyCdId(myCdId);
+
+    if (comments.isEmpty()) {
+      throw new CdCommentListEmptyException();
+    }
+
+    return comments.stream()
+        .map(comment -> new CdCommentResponse(
+            comment.getId(),
+            comment.getMyCd().getId(),
+            comment.getUser().getId(),
+            comment.getUser().getNickname(),
+            comment.getTimestamp(),
+            comment.getContent(),
+            comment.getCreatedAt()
+        ))
+        .collect(Collectors.toList());
+  }
+
   public CdCommentListResponse searchComments(Long myCdId, String keyword, int page, int size) {
     Pageable pageable = PageRequest.of(page, size);
     Page<CdComment> commentPage = cdCommentRepository.findByMyCdIdAndKeyword(myCdId, keyword,

--- a/roome/src/test/java/com/roome/domain/cdcomment/controller/CdCommentControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/cdcomment/controller/CdCommentControllerTest.java
@@ -77,6 +77,26 @@ class CdCommentControllerTest {
         .andExpect(jsonPath("$.data[0].content").value("이 곡 최고네요!"));
   }
 
+  @DisplayName("CD 전체 댓글 목록 조회 성공")
+  @WithMockUser
+  @Test
+  void getAllComments_Success() throws Exception {
+    List<CdCommentResponse> response = List.of(
+        createCdCommentResponse(1L, createCdCommentCreateRequest()),
+        createCdCommentResponse(2L, new CdCommentCreateRequest("04:20", "이 곡도 좋아요!"))
+    );
+
+    BDDMockito.given(cdCommentService.getAllComments(eq(1L)))
+        .willReturn(response);
+
+    mockMvc.perform(get("/api/my-cd/1/comments/all")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].content").value("이 곡 최고네요!"))
+        .andExpect(jsonPath("$[1].content").value("이 곡도 좋아요!"));
+  }
+
   @DisplayName("CD 댓글 검색 성공")
   @WithMockUser
   @Test

--- a/roome/src/test/java/com/roome/domain/cdcomment/service/CdCommentServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/cdcomment/service/CdCommentServiceTest.java
@@ -98,6 +98,40 @@ class CdCommentServiceTest {
   }
 
   @Test
+  @DisplayName("CD 전체 댓글 목록 조회 성공")
+  void getAllComments_Success() {
+    List<CdComment> comments = List.of(
+        cdComment,
+        CdComment.builder()
+            .id(2L)
+            .user(user)
+            .myCd(myCd)
+            .timestamp("04:20")
+            .content("이 곡도 좋아요!")
+            .build()
+    );
+
+    when(cdCommentRepository.findByMyCdId(1L)).thenReturn(comments);
+
+    List<CdCommentResponse> response = cdCommentService.getAllComments(1L);
+
+    assertThat(response).hasSize(2);
+    assertThat(response.get(0).getContent()).isEqualTo("이 곡 최고네요!");
+    assertThat(response.get(1).getContent()).isEqualTo("이 곡도 좋아요!");
+  }
+
+  @Test
+  @DisplayName("CD 전체 댓글 목록이 비어있을 때 예외 발생")
+  void getAllComments_EmptyList() {
+    // 빈 리스트 반환 설정
+    doReturn(List.of()).when(cdCommentRepository).findByMyCdId(1L);
+
+    // 예외 발생 검증
+    assertThatThrownBy(() -> cdCommentService.getAllComments(1L))
+        .isInstanceOf(CdCommentListEmptyException.class);
+  }
+
+  @Test
   @DisplayName("댓글 목록이 비어있을 때 예외 발생")
   void getComments_EmptyList() {
     Pageable pageable = PageRequest.of(0, 5);


### PR DESCRIPTION
## 📌 PR 제목 feat: CD 전체 댓글 조회 기능 추가

### ✅ PR 설명
CD에 등록된 전체 댓글을 조회하는 API를 추가하고, 관련된 서비스 및 테스트를 구현했습니다.

### 🏗 작업 내용
 - /api/my-cd/{myCdId}/comments/all 엔드포인트 추가
 - CdCommentService.getAllComments() 구현
 - CdCommentRepository.findByMyCdId() 추가
 - CdCommentControllerTest 및 CdCommentServiceTest에 테스트 코드 반영

### 📸 테스트 결과 (선택)
> 
![image](https://github.com/user-attachments/assets/70967829-cba0-4b51-ae8c-559e127dfed5)


### 🔗 관련 이슈 (선택)
> #209

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
