### PR TITLE
Refactor: 소셜 로그인 사용자 식별 로직 개선

### DIFF
--- a/roome/src/main/java/com/roome/domain/user/repository/UserRepository.java
+++ b/roome/src/main/java/com/roome/domain/user/repository/UserRepository.java
@@ -1,38 +1,38 @@
 package com.roome.domain.user.repository;
 
+import com.roome.domain.user.entity.Provider;
 import com.roome.domain.user.entity.User;
 import com.roome.global.jwt.exception.UserNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    default User getById(Long id) {
-        return findById(id)
-                .orElseThrow(UserNotFoundException::new);
-    }
+  default User getById(Long id) {
+    return findById(id)
+        .orElseThrow(UserNotFoundException::new);
+  }
 
-    Optional<User> findByProviderId(String providerId);
+  Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 
-    Optional<User> findByEmail(String email);
+  Optional<User> findByEmail(String email);
 
-    @Transactional
-    @Modifying(clearAutomatically = true)
-    @Query(
-            value = """
-                update users set last_login = :now where id = :userId
-                """,
-            nativeQuery = true
-    )
-    void updateLastLogin(Long userId, LocalDateTime now);
+  @Transactional
+  @Modifying(clearAutomatically = true)
+  @Query(
+      value = """
+          update users set last_login = :now where id = :userId
+          """,
+      nativeQuery = true
+  )
+  void updateLastLogin(Long userId, LocalDateTime now);
 
-    List<User> findByIdNot(Long id);
+  List<User> findByIdNot(Long id);
 }


### PR DESCRIPTION
## 📌 Refactor: 소셜 로그인 사용자 식별 로직 개선

### ✅ PR 설명
소셜 로그인 시 사용자 식별 로직을 변경했습니다. 소셜 로그인 시 이메일 대신 provider +provider id 조합으로 사용자를 식별하도록 변경했습니다.

### 🏗 작업 내용
- [ ] 같은 이메일이라도 다른 제공자로 로그인 시 별도 계정으로 생성
- [ ] UserRepository에 findByProviderAndProviderId 메서드 추가
- [ ] 관련 테스트 코드 수정 및 새 테스트 케이스 추가

### 📸 테스트 결과 (선택)
> 모든 테스트가 성공적으로 동작했습니다. 새로운 소셜 로그인 식별 로직이 정상 작동하는 것을 확인했습니다.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
