### PR TITLE
Fix: 방 조회시 방 주인의 닉네임도 응답되도록 수정

### DIFF
--- a/roome/src/main/java/com/roome/domain/room/dto/RoomResponseDto.java
+++ b/roome/src/main/java/com/roome/domain/room/dto/RoomResponseDto.java
@@ -17,6 +17,7 @@ public class RoomResponseDto {
     private Long roomId;
     private Long userId;
     private String theme;
+    private String nickname;
     private LocalDateTime createdAt;
     private List<FurnitureResponseDto> furnitures;
     private StorageLimitsDto storageLimits;
@@ -27,6 +28,7 @@ public class RoomResponseDto {
                 .roomId(room.getId())
                 .userId(room.getUser().getId())
                 .theme(room.getTheme().getThemeName())
+                .nickname(room.getUser().getNickname())
                 .createdAt(room.getCreatedAt())
                 .furnitures(room.getFurnitures() != null
                         ? room.getFurnitures().stream().map(FurnitureResponseDto::from).collect(Collectors.toList())


### PR DESCRIPTION
### ✅ PR 설명
방 조회시 방 주인의 닉네임도 응답되도록 수정

### 🏗 작업 내용
- [ ] 방 조회시 방 주인의 닉네임도 응답되도록 수정

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
