### PR TITLE
feat: CD 목록 조회 시 로그인한 사용자와 조회 대상 사용자 구분 가능하도록 수정

### DIFF
--- a/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
@@ -11,10 +11,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @Tag(name = "My CD", description = "사용자의 MyCd 관리 API - CD 추가, 조회, 삭제")
 @RestController
 @RequestMapping("/api/my-cd")
@@ -33,10 +35,11 @@ public class MyCdController {
         .body(myCdService.addCdToMyList(userId, myCdRequest));
   }
 
-  @Operation(summary = "내 CD 목록 조회", description = "사용자의 MyCd 목록을 조회합니다. 키워드 검색을 지원합니다.")
+  @Operation(summary = "CD 목록 조회", description = "특정 사용자의 MyCd 목록을 조회합니다. 키워드 검색을 지원합니다.")
   @GetMapping
   public ResponseEntity<MyCdListResponse> getMyCdList(
-      @AuthenticatedUser Long userId,
+      @AuthenticatedUser Long userId, // 로그인한 사용자 ID
+      @RequestParam(value = "targetUserId", required = false) Long targetUserId, // 조회 대상 사용자 ID
       @Parameter(description = "커서 기반 페이지네이션 (마지막 조회한 myCdId)")
       @RequestParam(value = "cursor", required = false) Long cursor,
       @Parameter(description = "한 번에 가져올 개수 (기본값: 15)", example = "15")
@@ -44,7 +47,11 @@ public class MyCdController {
       @Parameter(description = "CD 제목 또는 가수명으로 검색")
       @RequestParam(value = "keyword", required = false) String keyword
   ) {
-    return ResponseEntity.ok(myCdService.getMyCdList(userId, keyword, cursor, size));
+    Long finalUserId = (targetUserId != null) ? targetUserId : userId; // targetUserId가 있으면 해당 유저 조회
+
+    log.info("요청한 사용자 ID: {}, 조회 대상 사용자 ID: {}", userId, finalUserId);
+
+    return ResponseEntity.ok(myCdService.getMyCdList(finalUserId, keyword, cursor, size));
   }
 
   @Operation(summary = "특정 CD 조회", description = "사용자의 MyCd 목록에서 특정 CD를 조회합니다.")

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -24,6 +24,7 @@ import com.roome.global.jwt.exception.UserNotFoundException;
 import jakarta.transaction.Transactional;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +33,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -88,7 +90,7 @@ public class MyCdService {
   }
 
   public MyCdListResponse getMyCdList(Long userId, String keyword, Long cursor, int size) {
-    validateUser(userId);
+    log.info("조회할 사용자 ID: {}", userId); // 조회 대상 사용자 로그 확인
 
     boolean isKeywordSearch = keyword != null && !keyword.trim().isEmpty();
     Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.ASC, "id"));
@@ -117,6 +119,7 @@ public class MyCdService {
 
     return MyCdListResponse.fromEntities(myCdsPage.getContent(), totalCount);
   }
+
 
   public MyCdResponse getMyCd(Long userId, Long myCdId) {
     validateUser(userId);


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
- `targetUserId` 요청 파라미터 추가하여 특정 사용자의 CD 목록 조회 가능하도록 변경
- `targetUserId`가 없을 경우, 기본적으로 로그인한 사용자의 목록을 조회하도록 설정
- 기존 `userId` 기반 요청을 `targetUserId`로 변경하여 API 일관성 유지
- 로그 추가 (`log.info()`)로 요청한 사용자와 조회 대상 사용자 구분 가능하도록 개선"

### 🏗 작업 내용
- [ ] TODO 1 (어떤 기능을 개발했는지)
- [ ] TODO 2 (관련 API가 있다면 명시)
- [ ] TODO 3 (테스트 여부 등)

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
