### PR TITLE
Fix: 출석체크 포인트 획득 기능에서 NPE, 포인트 테이블에 획득한 포인트가 update 되지 않던 문제 해결

### DIFF
--- a/roome/src/main/java/com/roome/domain/auth/service/CustomOAuth2UserService.java
+++ b/roome/src/main/java/com/roome/domain/auth/service/CustomOAuth2UserService.java
@@ -130,10 +130,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
       // provider가 다르면 같은 이메일이어도 새로운 계정 생성
       log.info("새 사용자 생성: 이메일={}, 제공자={}", response.getEmail(), provider);
       return userRepository.save(
-          User.builder().name(response.getName()).nickname(response.getName())
-              .email(response.getEmail()).profileImage(response.getProfileImageUrl())
-              .provider(provider).providerId(providerId).status(Status.OFFLINE)
-              .lastLogin(LocalDateTime.now()).point(new Point(null, 0, 0, 0)).build());
+          User.create(
+                  response.getName(),
+                  response.getName(),
+                  response.getEmail(),
+                  response.getProfileImageUrl(),
+                  provider,
+                  providerId,
+                  LocalDateTime.now()
+          )
+      );
     });
   }
 }

--- a/roome/src/main/java/com/roome/domain/furniture/entity/Furniture.java
+++ b/roome/src/main/java/com/roome/domain/furniture/entity/Furniture.java
@@ -9,6 +9,7 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -51,6 +52,23 @@ public class Furniture {
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public static List<Furniture> createDefaultFurnitures(Room room, LocalDateTime now) {
+        Furniture bookshelf = init(room, FurnitureType.BOOKSHELF, now);
+        Furniture cdRack = init(room, FurnitureType.CD_RACK, now);
+        return List.of(bookshelf, cdRack);
+    }
+
+    public static Furniture init(Room room, FurnitureType furnitureType, LocalDateTime now) {
+        Furniture furniture = new Furniture();
+        furniture.room = room;
+        furniture.furnitureType = furnitureType;
+        furniture.isVisible = false;
+        furniture.level = 1;
+        furniture.createdAt = now;
+        furniture.updatedAt= now;
+        return furniture;
     }
 
     public int getMaxCapacity(){

--- a/roome/src/main/java/com/roome/domain/point/entity/Point.java
+++ b/roome/src/main/java/com/roome/domain/point/entity/Point.java
@@ -47,6 +47,17 @@ public class Point {
     this.updatedAt = LocalDateTime.now();
   }
 
+  public static Point init(User user, LocalDateTime now) {
+    Point point = new Point();
+    point.user = user;
+    point.balance = 0;
+    point.totalEarned = 0;
+    point.totalUsed = 0;
+    point.createdAt = now;
+    point.updatedAt = now;
+    return point;
+  }
+
   // 포인트 적립
   public void addPoints(int amount) {
     this.balance += amount;

--- a/roome/src/main/java/com/roome/domain/room/entity/Room.java
+++ b/roome/src/main/java/com/roome/domain/room/entity/Room.java
@@ -57,6 +57,15 @@ public class Room {
   @Builder.Default
   private List<Furniture> furnitures = new ArrayList<>();
 
+  public static Room init(User user, LocalDateTime now) {
+    Room room = new Room();
+    room.user = user;
+    room.theme = RoomTheme.BASIC;
+    room.createdAt = now;
+    room.furnitures.addAll(Furniture.createDefaultFurnitures(room, now));
+    return room;
+  }
+
   public int getMaxMusic() {
     return furnitures.stream()
         .filter(f -> f.getFurnitureType() == FurnitureType.CD_RACK)

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -13,7 +13,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -82,15 +81,27 @@ public class User extends BaseTimeEntity {
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   private Point point;
 
-  @PrePersist
-  public void prePersist() {
-    if (this.point == null) {
-      this.point = new Point(this, 0, 0, 0);
-    }
-
-    if (this.room == null) {
-      this.room = Room.builder().user(this).build();
-    }
+  public static User create(
+          String name,
+          String nickname,
+          String email,
+          String profileImage,
+          Provider provider,
+          String providerId,
+          LocalDateTime now
+  ) {
+    User user = new User();
+    user.name = name;
+    user.nickname = nickname;
+    user.email = email;
+    user.status = Status.ONLINE;
+    user.profileImage = profileImage;
+    user.provider = provider;
+    user.providerId = providerId;
+    user.lastLogin = now;
+    user.room = Room.init(user, now);
+    user.point = Point.init(user, now);
+    return user;
   }
 
   public void updateProfile(String nickname, String bio) {

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -98,7 +98,6 @@ public class User extends BaseTimeEntity {
     user.profileImage = profileImage;
     user.provider = provider;
     user.providerId = providerId;
-    user.lastLogin = now;
     user.room = Room.init(user, now);
     user.point = Point.init(user, now);
     return user;
@@ -160,7 +159,7 @@ public class User extends BaseTimeEntity {
 
   public boolean isAttendanceToday(LocalDateTime now) {
     LocalDateTime midnight = now.with(LocalTime.MIDNIGHT);
-    return midnight.isEqual(lastLogin) || midnight.isAfter(lastLogin);
+    return lastLogin != null && (lastLogin.isEqual(midnight) || lastLogin.isAfter(midnight));
   }
 
   public void accumulatePoints(int point) {
@@ -181,7 +180,7 @@ public class User extends BaseTimeEntity {
     this.lastGuestbookReward = date;
   }
 
-  public void updateLastLogin() {
-    this.lastLogin = LocalDateTime.now();
+  public void updateLastLogin(LocalDateTime now) {
+    this.lastLogin = now;
   }
 }


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
해당 PR에서 수행한 작업을 간단히 설명해주세요.

### 🏗 작업 내용
- [ ] NPE 해결 ( User 생성시 연관된 엔티티가 같이 생성되지 않고 있어서 같이 생성되도록 수정 )
- [ ] 포인트 테이블에 획득한 포인트가 update 되지 않던 문제 해결 ( 로그인 메서드에 @Transactional 누락 )
- [ ] TODO 3 (테스트 여부 등)

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
제가 테스트 해본 결과 최초 로그인시 User가 생성되고, User와 연관된 Room, Point 테이블 정상적으로 생성되고, Room 생성되면서 기본 Furniture인 Bookshelf와 CdRack도 같이 정상적으로 생성되는 걸로 확인했습니다.
객체간의 연관관계도 정상적으로 맺어지는 것도 확인했습니다.

연관관계 맺는 부분으 @PrePersist 애노테이션이 아니라 그냥 메서드로 맺도록 변경했습니다.

소연님 - Room 엔티티의 init() 메서드, Furniture 엔티티의 createDefaultFurnitures() 메서드, init() 메서드
하연님 - User 엔티티의 create() 메서드, CustomOAuth2UserService 클래스의  updateOrCreateUser() 메서드

위 메서드들에서 초기 생성할 때 필드값이 올바른 값으로 설정되고 있는지 확인 한 번씩만 부탁드립니다.

user 최초 생성시 room, furniture, point 테이블 정상적으로 생성
![image](https://github.com/user-attachments/assets/713e0c4f-f1e1-42f1-9f27-2e4fb9f22dcd)

user 최초 생성시 room, point와 객체에서도 매핑이 잘되고, room과 defaultfurniture(bookshelf, cdrack)객체와도 연관관계가 잘 맺어집니다.
![image](https://github.com/user-attachments/assets/f367c5c4-b2ad-4e1e-8715-ab38e43413af)
![image](https://github.com/user-attachments/assets/889a13f8-98e9-4479-ac59-ea58b0fce953)

