### PR TITLE
fix: 도서 등록시 사용자가 이미 등록한 도서인지 확인하는 부분 오류 수정

### DIFF
--- a/roome/src/main/java/com/roome/domain/mybook/entity/repository/MyBookRepository.java
+++ b/roome/src/main/java/com/roome/domain/mybook/entity/repository/MyBookRepository.java
@@ -17,7 +17,7 @@ public interface MyBookRepository extends JpaRepository<MyBook, Long> {
                 .orElseThrow(MyBookNotFoundException::new);
     }
 
-    Optional<MyBook> findByBookId(Long bookId);
+    Optional<MyBook> findByRoomIdAndBookId(Long roomId, Long bookId);
 
     @Query(
             value = """

--- a/roome/src/main/java/com/roome/domain/mybook/service/MyBookService.java
+++ b/roome/src/main/java/com/roome/domain/mybook/service/MyBookService.java
@@ -51,7 +51,7 @@ public class MyBookService {
                     return bookRepository.save(bookEntity);
                 });
 
-        myBookRepository.findByBookId(book.getId())
+        myBookRepository.findByRoomIdAndBookId(room.getId(), book.getId())
                 .ifPresent(exist -> { throw new MyBookDuplicateException(); });
 
         MyBook myBook = myBookRepository.save(MyBook.create(loginUser, room, book));


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
해당 PR에서 수행한 작업을 간단히 설명해주세요.

### 🏗 작업 내용
- [ ] 현재 도서 등록을 하는 사용자의 방에 등록된 도서 뿐만 아니라 전체 사용자의 방에 등록된 도서 기준으로 등록 도서인지 확인 -> 등록하는 사용자의 방에 등록된 도서만 확인하도록 변경

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
