### PR TITLE
Feat: 특정 CD 조회 시 targetUserId 적용 기능 추가

### DIFF
--- a/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
@@ -58,11 +58,11 @@ public class MyCdController {
   @GetMapping("/{myCdId}")
   public ResponseEntity<MyCdResponse> getMyCd(
       @AuthenticatedUser Long userId,
-      @RequestParam(value = "targetUserId", required = false) Long targetUserId, // 조회 대상 사용자 ID
+      @RequestParam(value = "targetUserId") Long targetUserId, // targetUserId를 필수로 받도록 변경
       @Parameter(description = "조회할 MyCd ID", example = "1")
       @PathVariable Long myCdId
   ) {
-    return ResponseEntity.ok(myCdService.getMyCd(userId, myCdId, targetUserId));
+    return ResponseEntity.ok(myCdService.getMyCd(targetUserId, myCdId));
   }
 
   @Operation(summary = "CD 삭제", description = "사용자의 MyCd 목록에서 하나 이상의 CD를 삭제합니다.")

--- a/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
+++ b/roome/src/main/java/com/roome/domain/mycd/controller/MyCdController.java
@@ -58,10 +58,11 @@ public class MyCdController {
   @GetMapping("/{myCdId}")
   public ResponseEntity<MyCdResponse> getMyCd(
       @AuthenticatedUser Long userId,
+      @RequestParam(value = "targetUserId", required = false) Long targetUserId, // 조회 대상 사용자 ID
       @Parameter(description = "조회할 MyCd ID", example = "1")
       @PathVariable Long myCdId
   ) {
-    return ResponseEntity.ok(myCdService.getMyCd(userId, myCdId));
+    return ResponseEntity.ok(myCdService.getMyCd(userId, myCdId, targetUserId));
   }
 
   @Operation(summary = "CD 삭제", description = "사용자의 MyCd 목록에서 하나 이상의 CD를 삭제합니다.")

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -99,7 +99,8 @@ public class MyCdService {
     long totalCount;
 
     if (isKeywordSearch) {
-      myCdsPage = Optional.ofNullable(myCdRepository.searchByUserIdAndKeyword(userId, keyword, pageable))
+      myCdsPage = Optional.ofNullable(
+              myCdRepository.searchByUserIdAndKeyword(userId, keyword, pageable))
           .orElseGet(() -> Page.empty(pageable));
       totalCount = myCdRepository.countByUserIdAndKeyword(userId, keyword);
     } else {
@@ -107,7 +108,8 @@ public class MyCdService {
         myCdsPage = Optional.ofNullable(myCdRepository.findByUserIdOrderByIdAsc(userId, pageable))
             .orElseGet(() -> Page.empty(pageable));
       } else {
-        myCdsPage = Optional.ofNullable(myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor, pageable))
+        myCdsPage = Optional.ofNullable(
+                myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor, pageable))
             .orElseGet(() -> Page.empty(pageable));
       }
       totalCount = myCdRepository.countByUserId(userId);
@@ -120,11 +122,10 @@ public class MyCdService {
     return MyCdListResponse.fromEntities(myCdsPage.getContent(), totalCount);
   }
 
+  public MyCdResponse getMyCd(Long userId, Long myCdId, Long targetUserId) {
+    Long finalUserId = (targetUserId != null) ? targetUserId : userId; // targetUserId 우선 적용
 
-  public MyCdResponse getMyCd(Long userId, Long myCdId) {
-    validateUser(userId);
-
-    MyCd myCd = myCdRepository.findByIdAndUserId(myCdId, userId)
+    MyCd myCd = myCdRepository.findByIdAndUserId(myCdId, finalUserId)
         .orElseThrow(MyCdNotFoundException::new);
 
     return MyCdResponse.fromEntity(myCd);

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -122,10 +122,8 @@ public class MyCdService {
     return MyCdListResponse.fromEntities(myCdsPage.getContent(), totalCount);
   }
 
-  public MyCdResponse getMyCd(Long userId, Long myCdId, Long targetUserId) {
-    Long finalUserId = (targetUserId != null) ? targetUserId : userId; // targetUserId 우선 적용
-
-    MyCd myCd = myCdRepository.findByIdAndUserId(myCdId, finalUserId)
+  public MyCdResponse getMyCd(Long targetUserId, Long myCdId) {
+    MyCd myCd = myCdRepository.findByIdAndUserId(myCdId, targetUserId)
         .orElseThrow(MyCdNotFoundException::new);
 
     return MyCdResponse.fromEntity(myCd);


### PR DESCRIPTION
## 📌 PR 제목 Feat: 특정 CD 조회 시 targetUserId 적용 기능 추가

### ✅ PR 설명
특정 CD 조회 시 targetUserId를 적용하여 다른 사용자의 MyCd도 조회할 수 있도록 수정했습니다.

### 🏗 작업 내용
- [ ] GET /api/my-cd/{myCdId} API에서 targetUserId 추가
- [ ] MyCdService.getMyCd 수정 (targetUserId가 있을 경우 해당 사용자의 CD 조회)

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> #237 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
