### PR TITLE
Feat: 회원 탈퇴 로직 개선 및 Redis 재시도 적용

### DIFF
--- a/roome/build.gradle
+++ b/roome/build.gradle
@@ -28,58 +28,62 @@ repositories {
 
 dependencies {
 
-	// Spring Boot
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    // Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-	// Test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testImplementation 'org.junit.jupiter:junit-jupiter'
-	testImplementation 'org.mockito:mockito-junit-jupiter'
-	testImplementation 'org.mockito:mockito-core'
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation 'org.mockito:mockito-core'
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// MariaDB
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    // MariaDB
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
-	// H2
-	runtimeOnly 'com.h2database:h2'
+    // H2
+    runtimeOnly 'com.h2database:h2'
 
-	// OAuth2 및 Security
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
+    // OAuth2 및 Security
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	// JWT
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// queryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // queryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-	// SWAGGER
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    // SWAGGER
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
-	// AWS
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
+    // AWS
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 
-	// Redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-cache'
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
-	// Websocket
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    // Websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // Spring Retry
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 }
 
@@ -100,5 +104,5 @@ tasks.named('test') {
 }
 
 test {
-	systemProperty 'spring.profiles.active', 'test'
+    systemProperty 'spring.profiles.active', 'test'
 }

--- a/roome/src/main/java/com/roome/RoomeApplication.java
+++ b/roome/src/main/java/com/roome/RoomeApplication.java
@@ -2,11 +2,14 @@ package com.roome;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
+@EnableRetry
 public class RoomeApplication {
-	public static void main(String[] args) {
-		SpringApplication.run(RoomeApplication.class, args);
-	}
+
+  public static void main(String[] args) {
+    SpringApplication.run(RoomeApplication.class, args);
+  }
 
 }

--- a/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
+++ b/roome/src/main/java/com/roome/domain/auth/controller/AuthController.java
@@ -8,7 +8,9 @@ import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
 import com.roome.domain.user.service.UserService;
 import com.roome.global.exception.BusinessException;
-import com.roome.global.jwt.exception.InvalidRefreshTokenException;
+import com.roome.global.jwt.exception.InvalidJwtTokenException;
+import com.roome.global.jwt.exception.InvalidUserIdFormatException;
+import com.roome.global.jwt.exception.MissingUserIdFromTokenException;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.jwt.service.TokenService;
 import com.roome.global.service.RedisService;
@@ -47,19 +49,12 @@ public class AuthController {
   private final RedisService redisService;
   private final RoomService roomService;
 
-  @Operation(
-      summary = "사용자 정보 조회",
-      description = "Access Token으로 사용자 정보를 조회합니다.",
-      security = @SecurityRequirement(name = "bearerAuth")
-  )
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
-      @ApiResponse(responseCode = "401", description = "인증 실패 또는 유효하지 않은 토큰")
-  })
+  @Operation(summary = "사용자 정보 조회", description = "Access Token으로 사용자 정보를 조회합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 실패 또는 유효하지 않은 토큰")})
   @GetMapping("/user")
   public ResponseEntity<LoginResponse> getUserInfo(
-      @RequestHeader("Authorization") String authHeader
-  ) {
+      @RequestHeader("Authorization") String authHeader) {
     try {
       String accessToken = authHeader.substring(7);
       Long userId = tokenService.getUserIdFromToken(accessToken);
@@ -70,36 +65,23 @@ public class AuthController {
       String refreshToken = redisService.getRefreshToken(userId.toString());
       log.info("User ID: {}, Refresh Token: {}", userId, refreshToken);
 
-      LoginResponse loginResponse = LoginResponse.builder()
-          .accessToken(accessToken)
+      LoginResponse loginResponse = LoginResponse.builder().accessToken(accessToken)
           .refreshToken(refreshToken)
           .expiresIn(jwtTokenProvider.getAccessTokenExpirationTime() / 1000) // 초 단위로 변환
-          .user(LoginResponse.UserInfo.builder()
-              .userId(user.getId())
-              .nickname(user.getNickname())
-              .email(user.getEmail())
-              .roomId(roomInfo.getRoomId())
-              .profileImage(user.getProfileImage())
-              .build())
-          .build();
+          .user(LoginResponse.UserInfo.builder().userId(user.getId()).nickname(user.getNickname())
+              .email(user.getEmail()).roomId(roomInfo.getRoomId())
+              .profileImage(user.getProfileImage()).build()).build();
 
       return ResponseEntity.ok(loginResponse);
     } catch (Exception e) {
       log.error("사용자 정보 조회 중 오류: ", e);
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-          .body(null);
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
     }
   }
 
-  @Operation(
-      summary = "로그아웃",
-      description = "사용자를 로그아웃 처리하고 토큰을 무효화합니다.",
-      security = @SecurityRequirement(name = "bearerAuth")
-  )
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-  })
+  @Operation(summary = "로그아웃", description = "사용자를 로그아웃 처리하고 토큰을 무효화합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")})
   @Transactional
   @PostMapping("/logout")
   public ResponseEntity<?> logout(
@@ -122,9 +104,7 @@ public class AuthController {
         }
 
         // 리프레시 토큰 쿠키 삭제
-        ResponseCookie cookie = ResponseCookie.from("refresh_token", "")
-            .maxAge(0)
-            .path("/")
+        ResponseCookie cookie = ResponseCookie.from("refresh_token", "").maxAge(0).path("/")
             .build();
         response.addHeader("Set-Cookie", cookie.toString());
       }
@@ -132,55 +112,147 @@ public class AuthController {
       return ResponseEntity.ok(Map.of("message", "로그아웃 되었습니다."));
     } catch (Exception e) {
       log.error("로그아웃 중 오류 발생: ", e);
-      return ResponseEntity.internalServerError()
-          .body(Map.of("message", "로그아웃 처리 중 오류가 발생했습니다."));
+      return ResponseEntity.internalServerError().body(Map.of("message", "로그아웃 처리 중 오류가 발생했습니다."));
     }
   }
 
-  @Operation(
-      summary = "회원 탈퇴",
-      description = "현재 로그인된 사용자 계정을 삭제합니다.",
-      security = @SecurityRequirement(name = "bearerAuth")
-  )
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+  @Operation(summary = "회원 탈퇴", description = "현재 로그인된 사용자 계정을 삭제합니다.", security = @SecurityRequirement(name = "bearerAuth"))
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
       @ApiResponse(responseCode = "400", description = "잘못된 요청"),
       @ApiResponse(responseCode = "401", description = "인증 실패 또는 유효하지 않은 토큰"),
-      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-  })
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")})
   @DeleteMapping("/withdraw")
+  @Transactional // 트랜잭션 경계 명확화
   public ResponseEntity<MessageResponse> withdraw(
       @RequestHeader("Authorization") String authHeader) {
-    try {
-      String accessToken = authHeader.substring(7);
 
-      if (accessToken.isBlank() || !jwtTokenProvider.validateAccessToken(accessToken)) {
+    // 1. 토큰 파싱 및 검증
+    String accessToken;
+    Long userId;
+
+    try {
+      if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        log.warn("[회원탈퇴] 유효하지 않은 인증 헤더 형식");
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(new MessageResponse("유효한 인증 토큰이 필요합니다."));
+      }
+
+      accessToken = authHeader.substring(7);
+
+      if (accessToken.isBlank()) {
+        log.warn("[회원탈퇴] 빈 액세스 토큰");
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(new MessageResponse("유효한 액세스 토큰이 필요합니다."));
+      }
+
+      // 액세스 토큰 검증
+      if (!jwtTokenProvider.validateAccessToken(accessToken)) {
+        log.warn("[회원탈퇴] 유효하지 않은 액세스 토큰: {}", maskToken(accessToken));
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(new MessageResponse("유효하지 않은 액세스 토큰입니다."));
       }
 
-      // 유저 ID 추출 및 회원 탈퇴 처리
-      Long userId = tokenService.getUserIdFromToken(accessToken);
+      // 유저 ID 추출
+      try {
+        userId = tokenService.getUserIdFromToken(accessToken);
+        log.info("[회원탈퇴] 사용자 ID: {} 탈퇴 시작", userId);
+      } catch (InvalidJwtTokenException | InvalidUserIdFormatException |
+               MissingUserIdFromTokenException e) {
+        log.warn("[회원탈퇴] 토큰에서 사용자 ID 추출 실패: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(new MessageResponse("토큰에서 사용자 정보를 추출할 수 없습니다: " + e.getMessage()));
+      }
+
+    } catch (Exception e) {
+      log.error("[회원탈퇴] 토큰 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body(new MessageResponse("인증 처리 중 오류가 발생했습니다."));
+    }
+
+    // 2. Redis 작업 - 우선 시도 (DB 작업 전)
+    boolean redisSuccess = false;
+    try {
+      redisSuccess = executeRedisCleanup(userId.toString(), accessToken);
+    } catch (Exception e) {
+      // Redis 실패는 기록만 하고 계속 진행 (보상 트랜잭션에서 다시 시도)
+      log.warn("[회원탈퇴] Redis 작업 실패 (재시도 예정): userId={}, 사유={}", userId, e.getMessage());
+    }
+
+    // 3. DB 작업 (사용자 데이터 삭제)
+    try {
       userService.deleteUser(userId);
-
-      // Refresh Token 삭제
-      redisService.deleteRefreshToken(userId.toString());
-
-      // Access Token 블랙리스트 추가
-      redisService.addToBlacklist(accessToken, jwtTokenProvider.getAccessTokenExpirationTime());
-
-      return ResponseEntity.ok(new MessageResponse("회원 탈퇴가 완료되었습니다."));
-
-    } catch (InvalidRefreshTokenException e) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-          .body(new MessageResponse(e.getMessage()));
+      log.info("[회원탈퇴] DB 작업 성공: userId={}", userId);
     } catch (BusinessException e) {
+      log.error("[회원탈퇴] 비즈니스 예외: 코드={}, 메시지={}", e.getErrorCode(), e.getMessage());
       return ResponseEntity.status(HttpStatus.BAD_REQUEST)
           .body(new MessageResponse(e.getMessage()));
     } catch (Exception e) {
-      log.error("회원 탈퇴 중 오류 발생: ", e);
+      log.error("[회원탈퇴] DB 작업 실패: userId={}, 사유={}", userId, e.getMessage(), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .body(new MessageResponse("회원 탈퇴 처리 중 오류가 발생했습니다."));
+          .body(new MessageResponse("회원 탈퇴 처리 중 오류가 발생했습니다: " + e.getMessage()));
     }
+
+    // 4. Redis 작업이 실패했으면 보상 트랜잭션에서 다시 시도
+    if (!redisSuccess) {
+      try {
+        boolean retrySuccess = retryRedisCleanup(userId.toString(), accessToken);
+        log.info("[회원탈퇴] Redis 재시도 결과: userId={}, 성공={}", userId, retrySuccess);
+      } catch (Exception e) {
+        // Redis 재시도 실패는 로그만 남기고 성공 응답 (DB 작업은 이미 성공)
+        log.warn("[회원탈퇴] Redis 재시도 실패 (DB 작업은 성공): userId={}, 사유={}", userId, e.getMessage());
+      }
+    }
+
+    return ResponseEntity.ok(new MessageResponse("회원 탈퇴가 완료되었습니다."));
+  }
+
+  // Redis 작업 실행 메소드 (반환값: 성공 여부)
+  private boolean executeRedisCleanup(String userId, String accessToken) {
+    boolean refreshTokenDeleted = false;
+    boolean accessTokenBlacklisted = false;
+
+    try {
+      // Refresh Token 삭제
+      redisService.deleteRefreshToken(userId);
+      refreshTokenDeleted = true;
+      log.debug("[회원탈퇴] 리프레시 토큰 삭제 성공: userId={}", userId);
+
+      // Access Token 블랙리스트 추가
+      long remainingTime = jwtTokenProvider.getTokenTimeToLive(accessToken);
+      if (remainingTime > 0) {
+        redisService.addToBlacklist(accessToken, remainingTime);
+        accessTokenBlacklisted = true;
+        log.debug("[회원탈퇴] 액세스 토큰 블랙리스트 추가 성공: userId={}, 남은시간={}ms", userId, remainingTime);
+      } else {
+        accessTokenBlacklisted = true; // 이미 만료된 토큰은 블랙리스트에 추가할 필요 없음
+        log.debug("[회원탈퇴] 액세스 토큰 이미 만료됨: userId={}", userId);
+      }
+
+      return refreshTokenDeleted && accessTokenBlacklisted;
+    } catch (Exception e) {
+      log.warn(
+          "[회원탈퇴] Redis 작업 실패 상세: userId={}, refreshTokenDeleted={}, accessTokenBlacklisted={}, 사유={}",
+          userId, refreshTokenDeleted, accessTokenBlacklisted, e.getMessage());
+      throw e; // 상위 메서드에서 처리
+    }
+  }
+
+  // 보상 트랜잭션 - Redis 작업 재시도
+  @Transactional(noRollbackFor = Exception.class) // 예외가 발생해도 롤백하지 않음
+  public boolean retryRedisCleanup(String userId, String accessToken) {
+    try {
+      return executeRedisCleanup(userId, accessToken);
+    } catch (Exception e) {
+      log.warn("[회원탈퇴] Redis 보상 트랜잭션 실패: userId={}, 사유={}", userId, e.getMessage());
+      return false;
+    }
+  }
+
+  // 토큰 마스킹 (로그 보안)
+  private String maskToken(String token) {
+    if (token == null || token.length() < 10) {
+      return "[too short to mask]";
+    }
+    return token.substring(0, 5) + "..." + token.substring(token.length() - 5);
   }
 }

--- a/roome/src/main/java/com/roome/domain/guestbook/repository/GuestbookRepository.java
+++ b/roome/src/main/java/com/roome/domain/guestbook/repository/GuestbookRepository.java
@@ -2,18 +2,20 @@ package com.roome.domain.guestbook.repository;
 
 import com.roome.domain.guestbook.entity.Guestbook;
 import com.roome.domain.room.entity.Room;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface GuestbookRepository extends JpaRepository<Guestbook, Long> {
-    Page<Guestbook> findByRoom(Room room, Pageable pageable);
 
-    // 특정 방의 방명록이거나 특정 사용자가 작성한 방명록 목록 조회
-    @Query("SELECT g FROM Guestbook g WHERE g.room = :room OR g.user.id = :userId")
-    List<Guestbook> findAllByRoomOrUserId(@Param("room") Room room, @Param("userId") Long userId);
+  Page<Guestbook> findByRoom(Room room, Pageable pageable);
+
+  // 특정 방의 방명록이거나 특정 사용자가 작성한 방명록 목록 조회
+  @Query("SELECT g FROM Guestbook g WHERE g.room = :room OR g.user.id = :userId")
+  List<Guestbook> findAllByRoomOrUserId(@Param("room") Room room, @Param("userId") Long userId);
+
+  List<Guestbook> findAllByUserId(Long userId);
 }

--- a/roome/src/main/java/com/roome/domain/houseMate/repository/HousemateRepository.java
+++ b/roome/src/main/java/com/roome/domain/houseMate/repository/HousemateRepository.java
@@ -3,11 +3,15 @@ package com.roome.domain.houseMate.repository;
 import com.roome.domain.houseMate.entity.AddedHousemate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HousemateRepository extends JpaRepository<AddedHousemate, Long>, HousemateRepositoryCustom {
-    // 양방향 체크도 하나의 테이블에서 가능
-    boolean existsByUserIdAndAddedId(Long userId, Long targetId);
-    // 삭제도 단순화
-    void deleteByUserIdAndAddedId(Long userId, Long targetId);
-    // 사용자가 추가한 하우스메이트 관계와 사용자를 추가한 하우스메이트 관계 모두 삭제
-    void deleteByUserIdOrAddedId(Long userId, Long targetId);
+public interface HousemateRepository extends JpaRepository<AddedHousemate, Long>,
+    HousemateRepositoryCustom {
+
+  // 양방향 체크도 하나의 테이블에서 가능
+  boolean existsByUserIdAndAddedId(Long userId, Long targetId);
+
+  // 삭제도 단순화
+  void deleteByUserIdAndAddedId(Long userId, Long targetId);
+
+  // 사용자가 추가한 하우스메이트 관계와 사용자를 추가한 하우스메이트 관계 모두 삭제
+  int deleteByUserIdOrAddedId(Long userId, Long targetId);
 }

--- a/roome/src/main/java/com/roome/domain/point/repository/PointHistoryRepository.java
+++ b/roome/src/main/java/com/roome/domain/point/repository/PointHistoryRepository.java
@@ -2,7 +2,17 @@ package com.roome.domain.point.repository;
 
 import com.roome.domain.point.entity.PointHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+@Repository
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
 
+  @Modifying
+  @Transactional
+  @Query("DELETE FROM PointHistory p WHERE p.user.id = :userId")
+  int deleteByUserId(@Param("userId") Long userId);
 }

--- a/roome/src/main/java/com/roome/domain/point/repository/PointRepository.java
+++ b/roome/src/main/java/com/roome/domain/point/repository/PointRepository.java
@@ -2,12 +2,14 @@ package com.roome.domain.point.repository;
 
 import com.roome.domain.point.entity.Point;
 import com.roome.domain.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-
+@Repository
 public interface PointRepository extends JpaRepository<Point, Long> {
 
   Optional<Point> findByUser(User user);
+
+  Optional<Point> findByUserId(Long userId);
 }

--- a/roome/src/main/java/com/roome/domain/room/entity/Room.java
+++ b/roome/src/main/java/com/roome/domain/room/entity/Room.java
@@ -5,8 +5,20 @@ import com.roome.domain.furniture.entity.FurnitureType;
 import com.roome.domain.furniture.exception.BookshelfFullException;
 import com.roome.domain.room.exception.RoomAuthorizationException;
 import com.roome.domain.user.entity.User;
-import jakarta.persistence.*;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,29 +59,26 @@ public class Room {
   private List<Furniture> furnitures = new ArrayList<>();
 
   @Version
-  private Integer version;
-  
+  @Column(nullable = false)
+  private Integer version = 0;
+
   public static Room init(User user, LocalDateTime now) {
     Room room = new Room();
     room.user = user;
     room.theme = RoomTheme.BASIC;
     room.createdAt = now;
-    room.furnitures.addAll(Furniture.createDefaultFurnitures(room, now));
+//    room.furnitures.addAll(Furniture.createDefaultFurnitures(room, now));
     return room;
   }
 
   public int getMaxMusic() {
-    return furnitures.stream()
-        .filter(f -> f.getFurnitureType() == FurnitureType.CD_RACK)
-        .mapToInt(Furniture::getMaxCapacity)
-        .sum();
+    return furnitures.stream().filter(f -> f.getFurnitureType() == FurnitureType.CD_RACK)
+        .mapToInt(Furniture::getMaxCapacity).sum();
   }
 
   public int getMaxBooks() {
-    return furnitures.stream()
-        .filter(f -> f.getFurnitureType() == FurnitureType.BOOKSHELF)
-        .mapToInt(Furniture::getMaxCapacity)
-        .sum();
+    return furnitures.stream().filter(f -> f.getFurnitureType() == FurnitureType.BOOKSHELF)
+        .mapToInt(Furniture::getMaxCapacity).sum();
   }
 
   @PrePersist

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -71,22 +70,19 @@ public class User extends BaseTimeEntity {
   @Column(nullable = true)
   private LocalDateTime lastGuestbookReward;
 
+  // TODO: 추후 Redis 사용
+  @Column(length = 1000)
+  private String refreshToken;
+
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   @PrimaryKeyJoinColumn
   private Room room;
 
-  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   private Point point;
 
-  public static User create(
-      String name,
-      String nickname,
-      String email,
-      String profileImage,
-      Provider provider,
-      String providerId,
-      LocalDateTime now
-  ) {
+  public static User create(String name, String nickname, String email, String profileImage,
+      Provider provider, String providerId, LocalDateTime now) {
     User user = new User();
     user.name = name;
     user.nickname = nickname;
@@ -96,10 +92,7 @@ public class User extends BaseTimeEntity {
     user.provider = provider;
     user.providerId = providerId;
     user.room = Room.init(user, now);
-
-    Point point = Point.init(user, now);
-    user.point = point;
-
+    user.point = Point.init(user, now);
     return user;
   }
 
@@ -145,6 +138,10 @@ public class User extends BaseTimeEntity {
     this.status = status;
   }
 
+  public void updateRefreshToken(String refreshToken) {
+    this.refreshToken = refreshToken;
+  }
+
   public void updateProvider(Provider provider) {
     this.provider = provider;
   }
@@ -159,10 +156,6 @@ public class User extends BaseTimeEntity {
   }
 
   public void accumulatePoints(int point) {
-    if (this.point == null) {
-      // Point 객체가 없으면 새로 생성
-      this.point = Point.init(this, LocalDateTime.now());
-    }
     this.point.addPoints(point);
   }
 

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -71,10 +71,6 @@ public class User extends BaseTimeEntity {
   @Column(nullable = true)
   private LocalDateTime lastGuestbookReward;
 
-  // TODO: 추후 Redis 사용
-  @Column(length = 1000)
-  private String refreshToken;
-
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   @PrimaryKeyJoinColumn
   private Room room;
@@ -147,10 +143,6 @@ public class User extends BaseTimeEntity {
 
   public void updateStatus(Status status) {
     this.status = status;
-  }
-
-  public void updateRefreshToken(String refreshToken) {
-    this.refreshToken = refreshToken;
   }
 
   public void updateProvider(Provider provider) {

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -1,7 +1,5 @@
 package com.roome.domain.user.entity;
 
-import com.roome.domain.furniture.entity.Furniture;
-import com.roome.domain.furniture.entity.FurnitureType;
 import com.roome.domain.point.entity.Point;
 import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.exception.RoomAuthorizationException;
@@ -11,6 +9,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,9 +18,6 @@ import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -83,17 +79,17 @@ public class User extends BaseTimeEntity {
   @PrimaryKeyJoinColumn
   private Room room;
 
-  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
   private Point point;
 
   public static User create(
-          String name,
-          String nickname,
-          String email,
-          String profileImage,
-          Provider provider,
-          String providerId,
-          LocalDateTime now
+      String name,
+      String nickname,
+      String email,
+      String profileImage,
+      Provider provider,
+      String providerId,
+      LocalDateTime now
   ) {
     User user = new User();
     user.name = name;
@@ -104,10 +100,13 @@ public class User extends BaseTimeEntity {
     user.provider = provider;
     user.providerId = providerId;
     user.room = Room.init(user, now);
-    user.point = Point.init(user, now);
+
+    Point point = Point.init(user, now);
+    user.point = point;
+
     return user;
   }
-  
+
   public void updateProfile(String nickname, String bio) {
     boolean updated = false;
     if (nickname != null && !nickname.equals(this.nickname)) {
@@ -168,6 +167,10 @@ public class User extends BaseTimeEntity {
   }
 
   public void accumulatePoints(int point) {
+    if (this.point == null) {
+      // Point 객체가 없으면 새로 생성
+      this.point = Point.init(this, LocalDateTime.now());
+    }
     this.point.addPoints(point);
   }
 

--- a/roome/src/main/java/com/roome/domain/user/service/UserService.java
+++ b/roome/src/main/java/com/roome/domain/user/service/UserService.java
@@ -14,114 +14,174 @@ import com.roome.domain.mybookreview.entity.repository.MyBookReviewRepository;
 import com.roome.domain.mycd.entity.MyCd;
 import com.roome.domain.mycd.repository.MyCdCountRepository;
 import com.roome.domain.mycd.repository.MyCdRepository;
-import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.repository.RoomRepository;
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
 import com.roome.global.exception.BusinessException;
 import com.roome.global.exception.ErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class UserService {
-    private final UserRepository userRepository;
-    private final HousemateRepository housemateRepository;
-    private final RoomRepository roomRepository;
-    private final FurnitureRepository furnitureRepository;
-    private final MyBookRepository myBookRepository;
-    private final MyBookReviewRepository myBookReviewRepository;
-    private final MyCdRepository myCdRepository;
-    private final CdCommentRepository cdCommentRepository;
-    private final GuestbookRepository guestbookRepository;
-    private final MyCdCountRepository myCdCountRepository;
-    private final MyBookCountRepository myBookCountRepository;
 
-    public void deleteUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+  private final UserRepository userRepository;
+  private final HousemateRepository housemateRepository;
+  private final RoomRepository roomRepository;
+  private final FurnitureRepository furnitureRepository;
+  private final MyBookRepository myBookRepository;
+  private final MyBookReviewRepository myBookReviewRepository;
+  private final MyCdRepository myCdRepository;
+  private final CdCommentRepository cdCommentRepository;
+  private final GuestbookRepository guestbookRepository;
+  private final MyCdCountRepository myCdCountRepository;
+  private final MyBookCountRepository myBookCountRepository;
 
-        // 1. 하우스메이트 관계 삭제
-        deleteHousemateRelations(userId);
+  @Transactional(isolation = Isolation.REPEATABLE_READ)
+  public void deleteUser(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        // 2. 도서 관련 데이터 삭제
-        deleteBookRelatedData(userId);
+    try {
+      // 1. 하우스메이트 관계 삭제
+      deleteHousemateRelations(userId);
 
-        // 3. CD 관련 데이터 삭제
-        deleteCdRelatedData(userId);
+      // 2. 도서 관련 데이터 삭제
+      deleteBookRelatedData(userId);
 
-        // 4. 방명록 삭제
-        deleteGuestbookData(userId);
+      // 3. CD 관련 데이터 삭제
+      deleteCdRelatedData(userId);
 
-        // 5. 사용자 방 및 가구 삭제
-        deleteRoomAndFurniture(userId);
+      // 4. 방명록 삭제
+      deleteGuestbookData(userId);
 
-        // 6. 사용자 삭제
-        userRepository.delete(user);
+      // 5. 사용자 방 및 가구 삭제
+      deleteRoomAndFurniture(userId);
 
-        log.info("User and related data successfully deleted for userId: {}", userId);
+      // 6. 사용자 삭제
+      userRepository.delete(user);
+      log.info("[회원탈퇴] 사용자 삭제 완료: {}", userId);
+
+    } catch (Exception e) {
+      String errorMsg = String.format("[회원탈퇴] 연관 데이터 삭제 실패 - 롤백 수행: userId=%s, 오류=%s", userId,
+          e.getMessage());
+      log.error(errorMsg, e);
+      throw new RuntimeException("회원 탈퇴 중 오류가 발생했습니다.");
     }
+  }
 
-    private void deleteHousemateRelations(Long userId) {
-        // 양방향 관계 모두 삭제 (내가 추가한 것 + 나를 추가한 것)
-        housemateRepository.deleteByUserIdOrAddedId(userId, userId);
+  private void deleteHousemateRelations(Long userId) {
+    try {
+      // 양방향 관계 모두 삭제 (내가 추가한 것 + 나를 추가한 것)
+      int count = housemateRepository.deleteByUserIdOrAddedId(userId, userId);
+      log.debug("[회원탈퇴] 하우스메이트 관계 삭제 수: {}", count);
+    } catch (Exception e) {
+      log.error("[회원탈퇴] 하우스메이트 관계 삭제 실패: userId={}, 오류={}", userId, e.getMessage());
+      throw new RuntimeException("하우스메이트 관계 삭제 중 오류 발생: " + e.getMessage(), e);
     }
+  }
 
-    private void deleteRoomAndFurniture(Long userId) {
-        Room room = roomRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+  private void deleteRoomAndFurniture(Long userId) {
+    roomRepository.findByUserId(userId).ifPresentOrElse(room -> {
+      try {
+        List<Furniture> furnitures = furnitureRepository.findByRoomId(room.getId());
 
         // 방 가구 삭제
-        List<Furniture> furnitures = furnitureRepository.findByRoomId(room.getId());
-        furnitureRepository.deleteAll(furnitures);
+        if (!furnitures.isEmpty()) {
+          furnitureRepository.deleteAll(furnitures);
+          log.debug("[회원탈퇴] 가구 삭제 완료: {}개", furnitures.size());
+        }
 
         // 방 삭제
         roomRepository.delete(room);
-    }
+        log.debug("[회원탈퇴] 방 삭제 완료: roomId={}", room.getId());
+      } catch (Exception e) {
+        log.error("[회원탈퇴] 방 및 가구 삭제 실패: roomId={}, 오류={}", room.getId(), e.getMessage());
+        throw new RuntimeException("방 및 가구 삭제 중 오류 발생: " + e.getMessage(), e);
+      }
+    }, () -> log.info("[회원탈퇴] 방이 존재하지 않음: userId={}", userId));
+  }
 
-    private void deleteBookRelatedData(Long userId) {
-        // 도서 리뷰 삭제
-        myBookReviewRepository.deleteAllByUserId(userId);
+  private void deleteBookRelatedData(Long userId) {
+    try {
+      // 도서 리뷰 삭제
+      myBookReviewRepository.deleteAllByUserId(userId);
+      log.debug("[회원탈퇴] 도서 리뷰 삭제 완료: userId={}", userId);
 
-        // 도서 카운트 삭제
-        myBookCountRepository.findByUserId(userId)
-                .ifPresent(myBookCountRepository::delete);
+      // 도서 카운트 삭제
+      myBookCountRepository.findByUserId(userId).ifPresent(count -> {
+        myBookCountRepository.delete(count);
+        log.debug("[회원탈퇴] 도서 카운트 삭제 완료: countId={}", count.getId());
+      });
 
-        // 도서 데이터 삭제
-        List<MyBook> myBooks = myBookRepository.findAllByUserId(userId);
+      // 도서 데이터 삭제
+      List<MyBook> myBooks = myBookRepository.findAllByUserId(userId);
+      if (!myBooks.isEmpty()) {
         myBookRepository.deleteAll(myBooks);
+        log.debug("[회원탈퇴] 도서 데이터 삭제 완료: {}개", myBooks.size());
+      }
+    } catch (Exception e) {
+      log.error("[회원탈퇴] 도서 관련 데이터 삭제 실패: userId={}, 오류={}", userId, e.getMessage());
+      throw new RuntimeException("도서 관련 데이터 삭제 중 오류 발생: " + e.getMessage(), e);
     }
+  }
 
-    private void deleteCdRelatedData(Long userId) {
-        // CD 댓글 삭제
-        List<CdComment> comments = cdCommentRepository.findAllByUserId(userId);
+  private void deleteCdRelatedData(Long userId) {
+    try {
+      // CD 댓글 삭제
+      List<CdComment> comments = cdCommentRepository.findAllByUserId(userId);
+      if (!comments.isEmpty()) {
         cdCommentRepository.deleteAll(comments);
+        log.debug("[회원탈퇴] CD 댓글 삭제 완료: {}개", comments.size());
+      }
 
-        // CD 카운트 삭제
-        Room room = roomRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
-        myCdCountRepository.findByRoom(room)
-                .ifPresent(myCdCountRepository::delete);
-
-        // CD 데이터 삭제
-        List<MyCd> myCds = myCdRepository.findByUserId(userId);
+      // CD 데이터 삭제
+      List<MyCd> myCds = myCdRepository.findByUserId(userId);
+      if (!myCds.isEmpty()) {
         myCdRepository.deleteAll(myCds);
+        log.debug("[회원탈퇴] CD 데이터 삭제 완료: {}개", myCds.size());
+      }
+
+      // CD 카운트 삭제
+      roomRepository.findByUserId(userId).ifPresent(room -> {
+        myCdCountRepository.findByRoom(room).ifPresent(count -> {
+          myCdCountRepository.delete(count);
+          log.debug("[회원탈퇴] CD 카운트 삭제 완료: countId={}", count.getId());
+        });
+      });
+    } catch (Exception e) {
+      log.error("[회원탈퇴] CD 관련 데이터 삭제 실패: userId={}, 오류={}", userId, e.getMessage());
+      throw new RuntimeException("CD 관련 데이터 삭제 중 오류 발생: " + e.getMessage(), e);
     }
+  }
 
-    private void deleteGuestbookData(Long userId) {
-        Room room = roomRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
-
-        // 내 방의 방명록과 내가 작성한 방명록 모두 삭제
+  private void deleteGuestbookData(Long userId) {
+    try {
+      // 내 방의 방명록과 내가 작성한 방명록 모두 삭제
+      roomRepository.findByUserId(userId).ifPresentOrElse(room -> {
         List<Guestbook> guestbooks = guestbookRepository.findAllByRoomOrUserId(room, userId);
-        guestbookRepository.deleteAll(guestbooks);
+        if (!guestbooks.isEmpty()) {
+          guestbookRepository.deleteAll(guestbooks);
+          log.debug("[회원탈퇴] 방명록 삭제 완료: {}개", guestbooks.size());
+        }
+      }, () -> {
+        // 방이 없는 경우 사용자가 작성한 방명록만 삭제
+        List<Guestbook> guestbooks = guestbookRepository.findAllByUserId(userId);
+        if (!guestbooks.isEmpty()) {
+          guestbookRepository.deleteAll(guestbooks);
+          log.debug("[회원탈퇴] 사용자 작성 방명록만 삭제 완료: {}개", guestbooks.size());
+        }
+      });
+    } catch (Exception e) {
+      log.error("[회원탈퇴] 방명록 데이터 삭제 실패: userId={}, 오류={}", userId, e.getMessage());
+      throw new RuntimeException("방명록 데이터 삭제 중 오류 발생: " + e.getMessage(), e);
     }
-
+  }
 }

--- a/roome/src/main/java/com/roome/domain/user/service/UserService.java
+++ b/roome/src/main/java/com/roome/domain/user/service/UserService.java
@@ -106,18 +106,12 @@ public class UserService {
           log.debug("[회원탈퇴] 가구 삭제 완료: {}개", furnitures.size());
         }
 
-        // 방을 다시 조회하여 최신 상태 유지
-        room = roomRepository.findById(room.getId()).orElse(null);
-        if (room == null) {
-          log.warn("[회원탈퇴] 이미 삭제된 방 (roomId={})", room.getId());
-          return;
-        }
-
         // 방 삭제
         roomRepository.delete(room);
         log.debug("[회원탈퇴] 방 삭제 완료: roomId={}", room.getId());
       } catch (Exception e) {
-        log.error("[회원탈퇴] 방 및 가구 삭제 실패: roomId={}, 오류={}", room.getId(), e.getMessage());
+        log.error("[회원탈퇴] 방 및 가구 삭제 실패: userId={}, roomId={}, 오류={}", userId, room.getId(),
+            e.getMessage(), e);
         throw new RuntimeException("방 및 가구 삭제 중 오류 발생: " + e.getMessage(), e);
       }
     }, () -> log.info("[회원탈퇴] 방이 존재하지 않음: userId={}", userId));

--- a/roome/src/main/java/com/roome/global/jwt/controller/ReissueController.java
+++ b/roome/src/main/java/com/roome/global/jwt/controller/ReissueController.java
@@ -104,8 +104,9 @@ public class ReissueController {
       return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
           .body(new MessageResponse("데이터베이스 접근 중 오류가 발생했습니다."));
     } catch (Exception e) {
-      log.error("토큰 재발급 중 예상치 못한 오류 발생: ", e);
-      return ResponseEntity.internalServerError().body(new MessageResponse("토큰 재발급 중 오류가 발생했습니다."));
+      String errorMsg = String.format("토큰 재발급 중 오류 발생: %s", e.getMessage());
+      log.error(errorMsg, e);
+      return ResponseEntity.internalServerError().body(new MessageResponse(errorMsg));
     }
   }
 }

--- a/roome/src/main/java/com/roome/global/service/RedisService.java
+++ b/roome/src/main/java/com/roome/global/service/RedisService.java
@@ -3,7 +3,10 @@ package com.roome.global.service;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -16,12 +19,13 @@ public class RedisService {
   private static final String BLACKLIST_PREFIX = "BL:";
 
   // Refresh Token 저장
+  @Retryable(value = {
+      RedisConnectionFailureException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))
   public void saveRefreshToken(String userId, String refreshToken, long expiration) {
     String key = REFRESH_TOKEN_PREFIX + userId;
     try {
       redisTemplate.opsForValue().set(key, refreshToken, expiration, TimeUnit.MILLISECONDS);
-      log.info("Refresh Token 저장 성공 - Key: {}, Token: {}, Expiration: {} ms", key, refreshToken,
-          expiration);
+      log.debug("Refresh Token 저장 성공 - Key: {}, Expiration: {} ms", key, expiration);
     } catch (Exception e) {
       log.error("Refresh Token 저장 실패 - Key: {}, Error: {}", key, e.getMessage(), e);
       throw new RuntimeException("Refresh Token 저장 중 오류 발생", e);
@@ -29,11 +33,13 @@ public class RedisService {
   }
 
   // Refresh Token 조회
+  @Retryable(value = {
+      RedisConnectionFailureException.class}, maxAttempts = 2, backoff = @Backoff(delay = 500))
   public String getRefreshToken(String userId) {
     String key = REFRESH_TOKEN_PREFIX + userId;
     try {
       String refreshToken = redisTemplate.opsForValue().get(key);
-      log.info("Refresh Token 조회 - Key: {}, Token: {}", key, refreshToken);
+      log.debug("Refresh Token 조회 - Key: {}, 존재여부: {}", key, refreshToken != null);
       return refreshToken;
     } catch (Exception e) {
       log.error("Refresh Token 조회 실패 - Key: {}, Error: {}", key, e.getMessage(), e);
@@ -42,35 +48,44 @@ public class RedisService {
   }
 
   // Refresh Token 삭제
-  public void deleteRefreshToken(String userId) {
+  @Retryable(value = {
+      RedisConnectionFailureException.class}, maxAttempts = 2, backoff = @Backoff(delay = 500))
+  public boolean deleteRefreshToken(String userId) {
     String key = REFRESH_TOKEN_PREFIX + userId;
     try {
-      redisTemplate.delete(key);
-      log.info("Refresh Token 삭제 성공 - Key: {}", key);
+      Boolean deleted = redisTemplate.delete(key);
+      boolean result = deleted != null && deleted;
+      log.debug("Refresh Token 삭제 결과 - Key: {}, 성공여부: {}", key, result);
+      return result;
     } catch (Exception e) {
       log.error("Refresh Token 삭제 실패 - Key: {}, Error: {}", key, e.getMessage(), e);
-      throw new RuntimeException("Refresh Token 삭제 중 오류 발생", e);
+      return false;
     }
   }
 
   // 액세스 토큰 블랙리스트 추가
-  public void addToBlacklist(String accessToken, long expiration) {
+  @Retryable(value = {
+      RedisConnectionFailureException.class}, maxAttempts = 2, backoff = @Backoff(delay = 500))
+  public boolean addToBlacklist(String accessToken, long expiration) {
     String key = BLACKLIST_PREFIX + accessToken;
     try {
       redisTemplate.opsForValue().set(key, "logout", expiration, TimeUnit.MILLISECONDS);
-      log.info("액세스 토큰 블랙리스트 추가 - Key: {}, Expiration: {} ms", key, expiration);
+      log.debug("블랙리스트 추가 완료 - Key: {}, Expiration: {} ms", key, expiration);
+      return true;
     } catch (Exception e) {
-      log.error("액세스 토큰 블랙리스트 추가 실패 - Key: {}, Error: {}", key, e.getMessage(), e);
-      throw new RuntimeException("액세스 토큰 블랙리스트 추가 중 오류 발생", e);
+      log.error("블랙리스트 추가 실패 - Key: {}, Error: {}", key, e.getMessage(), e);
+      return false;
     }
   }
 
-  // 블랙리스트 토큰 확인
+  // 토큰이 블랙리스트에 있는지 확인
+  @Retryable(value = {
+      RedisConnectionFailureException.class}, maxAttempts = 2, backoff = @Backoff(delay = 300))
   public boolean isBlacklisted(String accessToken) {
     String key = BLACKLIST_PREFIX + accessToken;
     try {
       boolean isBlacklisted = Boolean.TRUE.equals(redisTemplate.hasKey(key));
-      log.info("블랙리스트 토큰 확인 - Key: {}, isBlacklisted: {}", key, isBlacklisted);
+      log.trace("블랙리스트 토큰 확인 - Key: {}, isBlacklisted: {}", key, isBlacklisted);
       return isBlacklisted;
     } catch (Exception e) {
       log.error("블랙리스트 토큰 확인 실패 - Key: {}, Error: {}", key, e.getMessage(), e);

--- a/roome/src/test/java/com/roome/domain/auth/controller/AuthControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/auth/controller/AuthControllerTest.java
@@ -1,5 +1,15 @@
 package com.roome.domain.auth.controller;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.roome.domain.room.service.RoomService;
 import com.roome.domain.user.repository.UserRepository;
@@ -17,103 +27,98 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @WebMvcTest(controllers = AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-    @MockBean
-    private JwtTokenProvider jwtTokenProvider;
+  @MockBean
+  private JwtTokenProvider jwtTokenProvider;
 
-    @MockBean
-    private TokenService tokenService;
+  @MockBean
+  private TokenService tokenService;
 
-    @MockBean
-    private UserService userService;
+  @MockBean
+  private UserService userService;
 
-    @MockBean
-    private RedisService redisService;
+  @MockBean
+  private RedisService redisService;
 
-    @MockBean
-    private UserRepository userRepository;
+  @MockBean
+  private UserRepository userRepository;
 
-    @MockBean
-    private RoomService roomService;
+  @MockBean
+  private RoomService roomService;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Test
-    @DisplayName("로그아웃 시 Access Token이 Redis 블랙리스트에 추가된다.")
-    void logoutSuccess_RedisBlacklist() throws Exception {
-        // Given
-        String accessToken = "mockAccessToken";
-        String userId = "1";
-        long expiration = 3600000L; // 1시간
+  @Test
+  @DisplayName("로그아웃 시 Access Token이 Redis 블랙리스트에 추가된다.")
+  void logoutSuccess_RedisBlacklist() throws Exception {
+    // Given
+    String accessToken = "mockAccessToken";
+    String userId = "1";
+    long expiration = 3600000L; // 1시간
 
-        when(jwtTokenProvider.getUserIdFromToken(accessToken)).thenReturn(userId);
-        when(jwtTokenProvider.getTokenTimeToLive(accessToken)).thenReturn(expiration);
-        doNothing().when(redisService).deleteRefreshToken(anyString());
-        doNothing().when(redisService).addToBlacklist(anyString(), anyLong());
+    when(jwtTokenProvider.getUserIdFromToken(accessToken)).thenReturn(userId);
+    when(jwtTokenProvider.getTokenTimeToLive(accessToken)).thenReturn(expiration);
+    when(redisService.deleteRefreshToken(anyString())).thenReturn(true);
+    when(redisService.addToBlacklist(anyString(), anyLong())).thenReturn(true);
 
-        // When & Then
-        mockMvc.perform(post("/api/auth/logout")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .with(csrf()))
-                .andExpect(status().isOk());
+    // When & Then
+    mockMvc.perform(post("/api/auth/logout")
+            .header("Authorization", "Bearer " + accessToken)
+            .with(csrf()))
+        .andExpect(status().isOk());
 
-        // Verify 블랙리스트 추가 확인
-        verify(redisService, times(1)).addToBlacklist(eq(accessToken), eq(expiration));
-        verify(redisService, times(1)).deleteRefreshToken(eq(userId));
-    }
+    // Verify 블랙리스트 추가 확인
+    verify(redisService, times(1)).addToBlacklist(eq(accessToken), eq(expiration));
+    verify(redisService, times(1)).deleteRefreshToken(eq(userId));
+  }
 
-    @Test
-    @DisplayName("로그아웃 시 Redis에서 Refresh Token이 삭제된다.")
-    void logoutSuccess_RedisTokenDeleted() throws Exception {
-        // Given
-        String accessToken = "mockAccessToken";
-        String userId = "1";
-        long expiration = 3600000L; // 1시간
+  @Test
+  @DisplayName("로그아웃 시 Redis에서 Refresh Token이 삭제된다.")
+  void logoutSuccess_RedisTokenDeleted() throws Exception {
+    // Given
+    String accessToken = "mockAccessToken";
+    String userId = "1";
+    long expiration = 3600000L; // 1시간
 
-        when(jwtTokenProvider.getUserIdFromToken(accessToken)).thenReturn(userId);
-        when(jwtTokenProvider.getTokenTimeToLive(accessToken)).thenReturn(expiration);
-        doNothing().when(redisService).deleteRefreshToken(anyString());
-        doNothing().when(redisService).addToBlacklist(anyString(), anyLong());
+    when(jwtTokenProvider.getUserIdFromToken(accessToken)).thenReturn(userId);
+    when(jwtTokenProvider.getTokenTimeToLive(accessToken)).thenReturn(expiration);
+    when(redisService.deleteRefreshToken(anyString())).thenReturn(true);
+    when(redisService.addToBlacklist(anyString(), anyLong())).thenReturn(true);
 
-        // When & Then
-        mockMvc.perform(post("/api/auth/logout")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .with(csrf()))
-                .andExpect(status().isOk());
+    // When & Then
+    mockMvc.perform(post("/api/auth/logout")
+            .header("Authorization", "Bearer " + accessToken)
+            .with(csrf()))
+        .andExpect(status().isOk());
 
-        // Verify Redis에서 Refresh Token 삭제 확인
-        verify(redisService, times(1)).deleteRefreshToken(eq(userId));
-        verify(redisService, times(1)).addToBlacklist(eq(accessToken), eq(expiration));
-    }
+    // Verify Redis에서 Refresh Token 삭제 확인
+    verify(redisService, times(1)).deleteRefreshToken(eq(userId));
+    verify(redisService, times(1)).addToBlacklist(eq(accessToken), eq(expiration));
+  }
 
-    @Test
-    @DisplayName("잘못된 Access Token으로 로그아웃 시 Redis 블랙리스트에 등록되지 않는다.")
-    void logoutFail_InvalidAccessToken() throws Exception {
-        // Given
-        String invalidToken = "invalidAccessToken";
+  @Test
+  @DisplayName("잘못된 Access Token으로 로그아웃 시 Redis 블랙리스트에 등록되지 않는다.")
+  void logoutFail_InvalidAccessToken() throws Exception {
+    // Given
+    String invalidToken = "invalidAccessToken";
 
-        when(jwtTokenProvider.getUserIdFromToken(invalidToken)).thenThrow(new IllegalArgumentException("Invalid Token"));
+    when(jwtTokenProvider.getUserIdFromToken(invalidToken)).thenThrow(
+        new IllegalArgumentException("Invalid Token"));
 
-        // When & Then
-        mockMvc.perform(post("/api/auth/logout")
-                        .header("Authorization", "Bearer " + invalidToken)
-                        .with(csrf()))
-                .andExpect(status().isInternalServerError());
+    // When & Then
+    mockMvc.perform(post("/api/auth/logout")
+            .header("Authorization", "Bearer " + invalidToken)
+            .with(csrf()))
+        .andExpect(status().isInternalServerError());
 
-        // Verify Redis 블랙리스트 등록이 호출되지 않음
-        verify(redisService, times(0)).addToBlacklist(anyString(), anyLong());
-    }
+    // Verify Redis 블랙리스트 등록이 호출되지 않음
+    verify(redisService, times(0)).addToBlacklist(anyString(), anyLong());
+  }
 }

--- a/roome/src/test/java/com/roome/domain/auth/controller/WithdrawControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/auth/controller/WithdrawControllerTest.java
@@ -1,109 +1,90 @@
 package com.roome.domain.auth.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.roome.domain.room.service.RoomService;
-import com.roome.domain.user.repository.UserRepository;
-import com.roome.domain.user.service.UserService;
-import com.roome.global.jwt.service.JwtTokenProvider;
-import com.roome.global.jwt.service.TokenService;
-import com.roome.global.service.RedisService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = AuthController.class)
-@AutoConfigureMockMvc(addFilters = false)
+import com.roome.domain.user.service.UserService;
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+import com.roome.global.jwt.service.JwtTokenProvider;
+import com.roome.global.jwt.service.TokenService;
+import com.roome.global.service.RedisService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 @ExtendWith(MockitoExtension.class)
 class WithdrawControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @InjectMocks
+  private AuthController authController;
 
-    @MockBean
-    private JwtTokenProvider jwtTokenProvider;
+  @Mock
+  private UserService userService;
 
-    @MockBean
-    private TokenService tokenService;
+  @Mock
+  private TokenService tokenService;
 
-    @MockBean
-    private UserService userService;
+  @Mock
+  private JwtTokenProvider jwtTokenProvider;
 
-    @MockBean
-    private RedisService redisService;
+  @Mock
+  private RedisService redisService;
 
-    @MockBean
-    private UserRepository userRepository;
+  private MockMvc mockMvc;
 
-    @MockBean
-    private RoomService roomService;
+  private static final String VALID_TOKEN = "valid.access.token";
+  private static final Long USER_ID = 1L;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.standaloneSetup(authController).build();
+    lenient().when(jwtTokenProvider.validateAccessToken(VALID_TOKEN)).thenReturn(true);
+    lenient().when(tokenService.getUserIdFromToken(VALID_TOKEN)).thenReturn(USER_ID);
+  }
 
-    @Test
-    @DisplayName("회원 탈퇴 성공 시 Access Token 블랙리스트 추가 및 Refresh Token 삭제")
-    void withdrawSuccess_BlacklistAndDeleteToken() throws Exception {
-        // Given
-        String accessToken = "mockAccessToken";
-        Long userId = 1L;
+  @Test
+  @DisplayName("회원 탈퇴 성공 테스트")
+  void withdrawSuccess() throws Exception {
+    mockMvc.perform(delete("/api/auth/withdraw").header(AUTHORIZATION, "Bearer " + VALID_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
 
-        when(jwtTokenProvider.validateAccessToken(accessToken)).thenReturn(true);
-        when(jwtTokenProvider.getAccessTokenExpirationTime()).thenReturn(3600000L); // 1시간
-        when(tokenService.getUserIdFromToken(accessToken)).thenReturn(userId);
-        doNothing().when(redisService).deleteRefreshToken(userId.toString());
-        doNothing().when(redisService).addToBlacklist(eq(accessToken), anyLong());
-        doNothing().when(userService).deleteUser(userId);
+    verify(userService, times(1)).deleteUser(USER_ID);
+  }
 
-        // When & Then
-        mockMvc.perform(delete("/api/auth/withdraw")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .with(csrf()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
+  @Test
+  @DisplayName("유효하지 않은 토큰으로 회원 탈퇴 시도")
+  void withdrawWithInvalidToken() throws Exception {
+    String invalidToken = "invalid.token";
+    lenient().when(jwtTokenProvider.validateAccessToken(invalidToken)).thenReturn(false);
 
-        // Verify: 블랙리스트 추가 & Refresh Token 삭제가 호출되었는지 확인
-        verify(redisService, times(1)).deleteRefreshToken(userId.toString());
-        verify(redisService, times(1)).addToBlacklist(eq(accessToken), anyLong());
-    }
+    mockMvc.perform(delete("/api/auth/withdraw").header(AUTHORIZATION, "Bearer " + invalidToken)
+        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isUnauthorized());
 
-    @Test
-    @DisplayName("유효하지 않은 Access Token으로 회원 탈퇴 시 401 반환")
-    void withdrawWithInvalidAccessToken_Returns401() throws Exception {
-        // Given
-        String accessToken = "invalidAccessToken";
+    verify(userService, times(0)).deleteUser(any());
+  }
 
-        when(jwtTokenProvider.validateAccessToken(accessToken)).thenReturn(false);
+  @Test
+  @DisplayName("사용자 서비스에서 비즈니스 예외 발생 시 회원 탈퇴 실패")
+  void withdrawFailsWhenUserServiceThrowsBusinessException() throws Exception {
+    doThrow(new BusinessException(ErrorCode.USER_NOT_FOUND)).when(userService).deleteUser(USER_ID);
 
-        // When & Then
-        mockMvc.perform(delete("/api/auth/withdraw")
-                        .header("Authorization", "Bearer " + accessToken)
-                        .with(csrf()))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value("유효하지 않은 액세스 토큰입니다."));
-
-        // Verify: 토큰이 유효하지 않아 호출되지 않음
-        verify(redisService, times(0)).deleteRefreshToken(anyString());
-        verify(userService, times(0)).deleteUser(anyLong());
-    }
-
-    @Test
-    @DisplayName("Authorization 헤더 없이 회원 탈퇴 시 401 반환")
-    void withdrawFail_NoAuthorizationToken() throws Exception {
-        // When & Then
-        mockMvc.perform(delete("/api/auth/withdraw")
-                        .with(csrf()))
-                .andExpect(status().isUnauthorized());
-    }
+    mockMvc.perform(delete("/api/auth/withdraw").header(AUTHORIZATION, "Bearer " + VALID_TOKEN)
+        .contentType(MediaType.APPLICATION_JSON)).andExpect(status().isBadRequest());
+  }
 }

--- a/roome/src/test/java/com/roome/domain/user/service/UserServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/user/service/UserServiceTest.java
@@ -1,12 +1,28 @@
 package com.roome.domain.user.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.roome.domain.cdcomment.entity.CdComment;
 import com.roome.domain.cdcomment.repository.CdCommentRepository;
+import com.roome.domain.furniture.entity.Furniture;
 import com.roome.domain.furniture.repository.FurnitureRepository;
+import com.roome.domain.guestbook.entity.Guestbook;
 import com.roome.domain.guestbook.repository.GuestbookRepository;
 import com.roome.domain.houseMate.repository.HousemateRepository;
+import com.roome.domain.mybook.entity.MyBook;
 import com.roome.domain.mybook.entity.repository.MyBookCountRepository;
 import com.roome.domain.mybook.entity.repository.MyBookRepository;
 import com.roome.domain.mybookreview.entity.repository.MyBookReviewRepository;
+import com.roome.domain.mycd.entity.MyCd;
 import com.roome.domain.mycd.repository.MyCdCountRepository;
 import com.roome.domain.mycd.repository.MyCdRepository;
 import com.roome.domain.room.entity.Room;
@@ -15,87 +31,172 @@ import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
 import com.roome.global.exception.BusinessException;
 import com.roome.global.exception.ErrorCode;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
-class UserServiceTest {
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UserServiceTest {
 
-    @InjectMocks
-    private UserService userService;
+  @InjectMocks
+  private UserService userService;
 
-    @Mock
-    private UserRepository userRepository;
-    @Mock
-    private HousemateRepository housemateRepository;
-    @Mock
-    private RoomRepository roomRepository;
-    @Mock
-    private FurnitureRepository furnitureRepository;
-    @Mock
-    private MyBookRepository myBookRepository;
-    @Mock
-    private MyBookReviewRepository myBookReviewRepository;
-    @Mock
-    private MyCdRepository myCdRepository;
-    @Mock
-    private CdCommentRepository cdCommentRepository;
-    @Mock
-    private GuestbookRepository guestbookRepository;
-    @Mock
-    private MyCdCountRepository myCdCountRepository;
-    @Mock
-    private MyBookCountRepository myBookCountRepository;
+  @Mock
+  private UserRepository userRepository;
 
-    private User testUser;
-    private Room testRoom;
+  @Mock
+  private HousemateRepository housemateRepository;
 
-    @BeforeEach
-    void setUp() {
-        testUser = User.builder()
-                .id(1L)
-                .email("test@example.com")
-                .nickname("testUser")
-                .build();
+  @Mock
+  private RoomRepository roomRepository;
 
-        testRoom = Room.builder()
-                .id(1L)
-                .user(testUser)
-                .build();
+  @Mock
+  private FurnitureRepository furnitureRepository;
 
-        lenient().when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        lenient().when(roomRepository.findByUserId(1L)).thenReturn(Optional.of(testRoom));
-    }
+  @Mock
+  private MyBookRepository myBookRepository;
 
-    @Test
-    void 회원탈퇴_성공() {
-        // given
-        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+  @Mock
+  private MyBookReviewRepository myBookReviewRepository;
 
-        // when
-        userService.deleteUser(1L);
+  @Mock
+  private MyCdRepository myCdRepository;
 
-        // then
-        verify(userRepository, times(1)).delete(testUser);
-    }
+  @Mock
+  private CdCommentRepository cdCommentRepository;
 
-    @Test
-    void 존재하지_않는_사용자_탈퇴_실패() {
-        // given
-        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+  @Mock
+  private GuestbookRepository guestbookRepository;
 
-        // when & then
-        BusinessException exception = assertThrows(BusinessException.class, () -> userService.deleteUser(1L));
-        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
-    }
+  @Mock
+  private MyCdCountRepository myCdCountRepository;
+
+  @Mock
+  private MyBookCountRepository myBookCountRepository;
+
+  private User testUser;
+  private Room testRoom;
+  private static final Long USER_ID = 1L;
+  private static final Long ROOM_ID = 1L;
+
+  @BeforeEach
+  void setUp() {
+    testUser = mock(User.class);
+    testRoom = mock(Room.class);
+
+    when(testRoom.getId()).thenReturn(ROOM_ID);
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(testUser));
+    when(roomRepository.findByUserId(USER_ID)).thenReturn(Optional.of(testRoom));
+
+    when(furnitureRepository.findByRoomId(ROOM_ID)).thenReturn(Collections.emptyList());
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 성공 - 모든 연관 데이터 삭제")
+  void deleteUserSuccess() {
+    // given
+    List<Furniture> furnitures = Arrays.asList(mock(Furniture.class), mock(Furniture.class));
+    List<MyBook> myBooks = Arrays.asList(mock(MyBook.class));
+    List<MyCd> myCds = Arrays.asList(mock(MyCd.class), mock(MyCd.class));
+    List<CdComment> comments = Arrays.asList(mock(CdComment.class));
+    List<Guestbook> guestbooks = Arrays.asList(mock(Guestbook.class), mock(Guestbook.class));
+
+    when(furnitureRepository.findByRoomId(ROOM_ID)).thenReturn(furnitures);
+    when(myBookRepository.findAllByUserId(USER_ID)).thenReturn(myBooks);
+    when(myCdRepository.findByUserId(USER_ID)).thenReturn(myCds);
+    when(cdCommentRepository.findAllByUserId(USER_ID)).thenReturn(comments);
+    when(guestbookRepository.findAllByRoomOrUserId(eq(testRoom), eq(USER_ID))).thenReturn(
+        guestbooks);
+    when(housemateRepository.deleteByUserIdOrAddedId(USER_ID, USER_ID)).thenReturn(3);
+
+    // when
+    userService.deleteUser(USER_ID);
+
+    // then
+    verify(housemateRepository, times(1)).deleteByUserIdOrAddedId(USER_ID, USER_ID);
+    verify(myBookReviewRepository, times(1)).deleteAllByUserId(USER_ID);
+    verify(myBookRepository, times(1)).deleteAll(myBooks);
+    verify(cdCommentRepository, times(1)).deleteAll(comments);
+    verify(myCdRepository, times(1)).deleteAll(myCds);
+    verify(guestbookRepository, times(1)).deleteAll(guestbooks);
+    verify(furnitureRepository, times(1)).deleteAll(furnitures);
+    verify(roomRepository, times(1)).delete(testRoom);
+    verify(userRepository, times(1)).delete(testUser);
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 성공 - 빈 컬렉션 처리")
+  void deleteUserSuccessWithEmptyCollections() {
+    // given
+    when(furnitureRepository.findByRoomId(ROOM_ID)).thenReturn(Collections.emptyList());
+    when(myBookRepository.findAllByUserId(USER_ID)).thenReturn(Collections.emptyList());
+    when(myCdRepository.findByUserId(USER_ID)).thenReturn(Collections.emptyList());
+    when(cdCommentRepository.findAllByUserId(USER_ID)).thenReturn(Collections.emptyList());
+    when(guestbookRepository.findAllByRoomOrUserId(eq(testRoom), eq(USER_ID))).thenReturn(
+        Collections.emptyList());
+
+    // when
+    userService.deleteUser(USER_ID);
+
+    // then
+    verify(furnitureRepository, never()).deleteAll(any(List.class));
+    verify(myBookRepository, never()).deleteAll(any(List.class));
+    verify(myCdRepository, never()).deleteAll(any(List.class));
+    verify(cdCommentRepository, never()).deleteAll(any(List.class));
+    verify(guestbookRepository, never()).deleteAll(any(List.class));
+    verify(userRepository, times(1)).delete(testUser);
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 시 사용자를 찾을 수 없는 경우")
+  void deleteUserWithNonExistentUser() {
+    // given
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> userService.deleteUser(USER_ID)).isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+    verify(housemateRepository, never()).deleteByUserIdOrAddedId(anyLong(), anyLong());
+    verify(userRepository, never()).delete(any(User.class));
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 시 방이 없는 경우에도 성공")
+  void deleteUserSuccessWithNoRoom() {
+    // given
+    when(roomRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+
+    // when
+    userService.deleteUser(USER_ID);
+
+    // then
+    verify(furnitureRepository, never()).findByRoomId(anyLong());
+    verify(myCdCountRepository, never()).findByRoom(any());
+    verify(userRepository, times(1)).delete(testUser);
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 시 하위 단계에서 예외 발생 시 전체 롤백")
+  void deleteUserFailsAndRollsBackWhenSubOperationFails() {
+    // given
+    doThrow(new RuntimeException("Database error")).when(housemateRepository)
+        .deleteByUserIdOrAddedId(USER_ID, USER_ID);
+
+    // when & then
+    assertThatThrownBy(() -> userService.deleteUser(USER_ID)).isInstanceOf(RuntimeException.class);
+
+    verify(userRepository, never()).delete(any(User.class));
+  }
 }

--- a/roome/src/test/java/com/roome/domain/user/service/UserServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/user/service/UserServiceTest.java
@@ -2,8 +2,6 @@ package com.roome.domain.user.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -25,13 +23,14 @@ import com.roome.domain.mybookreview.entity.repository.MyBookReviewRepository;
 import com.roome.domain.mycd.entity.MyCd;
 import com.roome.domain.mycd.repository.MyCdCountRepository;
 import com.roome.domain.mycd.repository.MyCdRepository;
+import com.roome.domain.point.repository.PointHistoryRepository;
+import com.roome.domain.point.repository.PointRepository;
 import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.repository.RoomRepository;
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
 import com.roome.global.exception.BusinessException;
 import com.roome.global.exception.ErrorCode;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -47,77 +46,73 @@ import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class UserServiceTest {
+class UserServiceTest {
 
   @InjectMocks
   private UserService userService;
 
   @Mock
   private UserRepository userRepository;
-
   @Mock
   private HousemateRepository housemateRepository;
-
   @Mock
   private RoomRepository roomRepository;
-
   @Mock
   private FurnitureRepository furnitureRepository;
-
   @Mock
   private MyBookRepository myBookRepository;
-
   @Mock
   private MyBookReviewRepository myBookReviewRepository;
-
   @Mock
   private MyCdRepository myCdRepository;
-
   @Mock
   private CdCommentRepository cdCommentRepository;
-
   @Mock
   private GuestbookRepository guestbookRepository;
-
   @Mock
   private MyCdCountRepository myCdCountRepository;
-
   @Mock
-  private MyBookCountRepository myBookCountRepository;
+  private PointHistoryRepository pointHistoryRepository;
+  @Mock
+  private PointRepository pointRepository;
+  @Mock
+  private MyBookCountRepository myBookCountRepository; // 추가
+
+  private static final Long USER_ID = 1L;
+  private static final Long ROOM_ID = 1L;
 
   private User testUser;
   private Room testRoom;
-  private static final Long USER_ID = 1L;
-  private static final Long ROOM_ID = 1L;
 
   @BeforeEach
   void setUp() {
     testUser = mock(User.class);
     testRoom = mock(Room.class);
 
+    when(testUser.getId()).thenReturn(USER_ID);
     when(testRoom.getId()).thenReturn(ROOM_ID);
+
     when(userRepository.findById(USER_ID)).thenReturn(Optional.of(testUser));
     when(roomRepository.findByUserId(USER_ID)).thenReturn(Optional.of(testRoom));
-
     when(furnitureRepository.findByRoomId(ROOM_ID)).thenReturn(Collections.emptyList());
+    when(myBookCountRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
   }
 
   @Test
   @DisplayName("회원 탈퇴 성공 - 모든 연관 데이터 삭제")
   void deleteUserSuccess() {
     // given
-    List<Furniture> furnitures = Arrays.asList(mock(Furniture.class), mock(Furniture.class));
-    List<MyBook> myBooks = Arrays.asList(mock(MyBook.class));
-    List<MyCd> myCds = Arrays.asList(mock(MyCd.class), mock(MyCd.class));
-    List<CdComment> comments = Arrays.asList(mock(CdComment.class));
-    List<Guestbook> guestbooks = Arrays.asList(mock(Guestbook.class), mock(Guestbook.class));
+    List<Furniture> furnitures = List.of(mock(Furniture.class), mock(Furniture.class));
+    List<MyBook> myBooks = List.of(mock(MyBook.class));
+    List<MyCd> myCds = List.of(mock(MyCd.class), mock(MyCd.class));
+    List<CdComment> comments = List.of(mock(CdComment.class));
+    List<Guestbook> guestbooks = List.of(mock(Guestbook.class), mock(Guestbook.class));
 
     when(furnitureRepository.findByRoomId(ROOM_ID)).thenReturn(furnitures);
     when(myBookRepository.findAllByUserId(USER_ID)).thenReturn(myBooks);
     when(myCdRepository.findByUserId(USER_ID)).thenReturn(myCds);
     when(cdCommentRepository.findAllByUserId(USER_ID)).thenReturn(comments);
-    when(guestbookRepository.findAllByRoomOrUserId(eq(testRoom), eq(USER_ID))).thenReturn(
-        guestbooks);
+    when(guestbookRepository.findAllByRoomOrUserId(testRoom, USER_ID)).thenReturn(guestbooks);
     when(housemateRepository.deleteByUserIdOrAddedId(USER_ID, USER_ID)).thenReturn(3);
 
     // when
@@ -139,23 +134,20 @@ public class UserServiceTest {
   @DisplayName("회원 탈퇴 성공 - 빈 컬렉션 처리")
   void deleteUserSuccessWithEmptyCollections() {
     // given
+    when(roomRepository.findByUserId(USER_ID)).thenReturn(Optional.of(testRoom));
     when(furnitureRepository.findByRoomId(ROOM_ID)).thenReturn(Collections.emptyList());
     when(myBookRepository.findAllByUserId(USER_ID)).thenReturn(Collections.emptyList());
     when(myCdRepository.findByUserId(USER_ID)).thenReturn(Collections.emptyList());
     when(cdCommentRepository.findAllByUserId(USER_ID)).thenReturn(Collections.emptyList());
-    when(guestbookRepository.findAllByRoomOrUserId(eq(testRoom), eq(USER_ID))).thenReturn(
+    when(guestbookRepository.findAllByRoomOrUserId(testRoom, USER_ID)).thenReturn(
         Collections.emptyList());
 
     // when
     userService.deleteUser(USER_ID);
 
     // then
-    verify(furnitureRepository, never()).deleteAll(any(List.class));
-    verify(myBookRepository, never()).deleteAll(any(List.class));
-    verify(myCdRepository, never()).deleteAll(any(List.class));
-    verify(cdCommentRepository, never()).deleteAll(any(List.class));
-    verify(guestbookRepository, never()).deleteAll(any(List.class));
     verify(userRepository, times(1)).delete(testUser);
+    verify(roomRepository, times(1)).delete(testRoom);
   }
 
   @Test
@@ -168,8 +160,7 @@ public class UserServiceTest {
     assertThatThrownBy(() -> userService.deleteUser(USER_ID)).isInstanceOf(BusinessException.class)
         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
 
-    verify(housemateRepository, never()).deleteByUserIdOrAddedId(anyLong(), anyLong());
-    verify(userRepository, never()).delete(any(User.class));
+    verify(userRepository, never()).delete(any());
   }
 
   @Test
@@ -182,8 +173,7 @@ public class UserServiceTest {
     userService.deleteUser(USER_ID);
 
     // then
-    verify(furnitureRepository, never()).findByRoomId(anyLong());
-    verify(myCdCountRepository, never()).findByRoom(any());
+    verify(roomRepository, never()).delete(any());
     verify(userRepository, times(1)).delete(testUser);
   }
 
@@ -197,6 +187,6 @@ public class UserServiceTest {
     // when & then
     assertThatThrownBy(() -> userService.deleteUser(USER_ID)).isInstanceOf(RuntimeException.class);
 
-    verify(userRepository, never()).delete(any(User.class));
+    verify(userRepository, never()).delete(any());
   }
 }

--- a/roome/src/test/java/com/roome/global/service/RedisServiceTest.java
+++ b/roome/src/test/java/com/roome/global/service/RedisServiceTest.java
@@ -1,0 +1,179 @@
+package com.roome.global.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+public class RedisServiceTest {
+
+  @InjectMocks
+  private RedisService redisService;
+
+  @Mock
+  private StringRedisTemplate redisTemplate;
+
+  @Mock
+  private ValueOperations<String, String> valueOps;
+
+  private static final String USER_ID = "123";
+  private static final String REFRESH_TOKEN = "refresh.token.123";
+  private static final String ACCESS_TOKEN = "access.token.456";
+  private static final long EXPIRATION = 3600000L; // 1시간
+
+  @Test
+  @DisplayName("Refresh Token 저장 성공")
+  void saveRefreshTokenSuccess() {
+    // given
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+    // when
+    redisService.saveRefreshToken(USER_ID, REFRESH_TOKEN, EXPIRATION);
+
+    // then
+    verify(valueOps, times(1)).set(eq("RT:" + USER_ID), eq(REFRESH_TOKEN), eq(EXPIRATION),
+        eq(TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  @DisplayName("Refresh Token 저장 실패")
+  void saveRefreshTokenFailure() {
+    // given
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    doThrow(new RedisConnectionFailureException("Connection refused")).when(valueOps)
+        .set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+
+    // when & then
+    assertThatThrownBy(
+        () -> redisService.saveRefreshToken(USER_ID, REFRESH_TOKEN, EXPIRATION)).isInstanceOf(
+        RuntimeException.class).hasMessageContaining("Refresh Token 저장 중 오류 발생");
+  }
+
+  @Test
+  @DisplayName("Refresh Token 조회 성공")
+  void getRefreshTokenSuccess() {
+    // given
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    when(valueOps.get("RT:" + USER_ID)).thenReturn(REFRESH_TOKEN);
+
+    // when
+    String result = redisService.getRefreshToken(USER_ID);
+
+    // then
+    assertThat(result).isEqualTo(REFRESH_TOKEN);
+  }
+
+  @Test
+  @DisplayName("Refresh Token 삭제 성공")
+  void deleteRefreshTokenSuccess() {
+    // given
+    when(redisTemplate.delete("RT:" + USER_ID)).thenReturn(true);
+
+    // when
+    boolean result = redisService.deleteRefreshToken(USER_ID);
+
+    // then
+    assertThat(result).isTrue();
+    verify(redisTemplate, times(1)).delete("RT:" + USER_ID);
+  }
+
+  @Test
+  @DisplayName("Refresh Token 삭제 실패 - Redis 서버 문제")
+  void deleteRefreshTokenFailure() {
+    // given
+    doThrow(new RedisConnectionFailureException("Connection refused")).when(redisTemplate)
+        .delete(anyString());
+
+    // when
+    boolean result = redisService.deleteRefreshToken(USER_ID);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("블랙리스트 추가 성공")
+  void addToBlacklistSuccess() {
+    // given
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+    // when
+    boolean result = redisService.addToBlacklist(ACCESS_TOKEN, EXPIRATION);
+
+    // then
+    assertThat(result).isTrue();
+    verify(valueOps, times(1)).set(eq("BL:" + ACCESS_TOKEN), eq("logout"), eq(EXPIRATION),
+        eq(TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  @DisplayName("블랙리스트 추가 실패")
+  void addToBlacklistFailure() {
+    // given
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    doThrow(new RedisConnectionFailureException("Connection refused")).when(valueOps)
+        .set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+
+    // when
+    boolean result = redisService.addToBlacklist(ACCESS_TOKEN, EXPIRATION);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("블랙리스트 확인 성공 - 토큰이 블랙리스트에 있음")
+  void isBlacklistedSuccess() {
+    // given
+    when(redisTemplate.hasKey("BL:" + ACCESS_TOKEN)).thenReturn(true);
+
+    // when
+    boolean result = redisService.isBlacklisted(ACCESS_TOKEN);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("블랙리스트 확인 성공 - 토큰이 블랙리스트에 없음")
+  void isBlacklistedTokenNotInBlacklist() {
+    // given
+    when(redisTemplate.hasKey("BL:" + ACCESS_TOKEN)).thenReturn(false);
+
+    // when
+    boolean result = redisService.isBlacklisted(ACCESS_TOKEN);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("블랙리스트 확인 실패")
+  void isBlacklistedFailure() {
+    // given
+    doThrow(new RedisConnectionFailureException("Connection refused")).when(redisTemplate)
+        .hasKey(anyString());
+
+    // when & then
+    assertThatThrownBy(() -> redisService.isBlacklisted(ACCESS_TOKEN)).isInstanceOf(
+        RuntimeException.class).hasMessageContaining("블랙리스트 토큰 확인 중 오류 발생");
+  }
+}


### PR DESCRIPTION
## 📌 Feat: 회원 탈퇴 로직 개선 및 Redis 재시도 적용

### ✅ PR 설명
회원 탈퇴 시 500 에러가 나던 문제를 개선하기 위해, 회원 탈퇴 및 Redis 관련 로직을 수정하고, 예외 처리 및 트랜잭션 안정성을 향상시켰습니다.

### 🏗 작업 내용
- [ ] RedisService에 Spring Retry 적용
- [ ] AuthController, UserService 리팩토링 및 예외 처리 개선
- [ ] 테스트 코드 업데이트

### 📸 테스트 결과 (선택)
> 
<img width="818" alt="스크린샷 2025-03-03 03 57 08" src="https://github.com/user-attachments/assets/6148bf80-2f0b-4ad2-99b6-adf3d75fc9b4" />


### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 회원가입/로그인 에러로 createDefaultFurnitures() 메서드 주석 처리하였습니다.
