### PR TITLE
Refactor: CD 목록 조회 API의 totalCount, firstMyCdId, lastMyCdId 개선

### DIFF
--- a/roome/src/main/java/com/roome/domain/mycd/exception/MyCdDatabaseException.java
+++ b/roome/src/main/java/com/roome/domain/mycd/exception/MyCdDatabaseException.java
@@ -1,0 +1,8 @@
+package com.roome.domain.mycd.exception;
+
+public class MyCdDatabaseException extends RuntimeException {
+
+  public MyCdDatabaseException(String message) {
+    super(message);
+  }
+}

--- a/roome/src/main/java/com/roome/domain/mycd/exception/MyCdPaginationException.java
+++ b/roome/src/main/java/com/roome/domain/mycd/exception/MyCdPaginationException.java
@@ -1,0 +1,8 @@
+package com.roome.domain.mycd.exception;
+
+public class MyCdPaginationException extends RuntimeException {
+
+  public MyCdPaginationException(String message) {
+    super(message);
+  }
+}

--- a/roome/src/main/java/com/roome/domain/mycd/repository/MyCdRepository.java
+++ b/roome/src/main/java/com/roome/domain/mycd/repository/MyCdRepository.java
@@ -26,6 +26,12 @@ public interface MyCdRepository extends JpaRepository<MyCd, Long> {
 
   Optional<MyCd> findByUserIdAndCdId(Long userId, Long cdId);
 
+  long countByUserId(Long userId);
+
+  Optional<MyCd> findFirstByUserIdOrderByIdAsc(Long userId);
+
+  Optional<MyCd> findFirstByUserIdOrderByIdDesc(Long userId);
+
   // 키워드 기반 검색 (CD 제목 또는 가수명)
   @Query("SELECT mc FROM MyCd mc JOIN mc.cd c " + "WHERE mc.user.id = :userId "
       + "AND (LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) "


### PR DESCRIPTION
## 📌 PR 제목 Refactor: CD 목록 조회 API의 totalCount, firstMyCdId, lastMyCdId 개선

### ✅ PR 설명
CD 목록 조회 API의 데이터 반환 로직을 개선하여 프론트엔드에서 요청한 형식과 맞도록 수정하였습니다.
이제 유저가 등록한 전체 CD 중에서 가장 첫 번째(firstMyCdId), 마지막(lastMyCdId) CD ID를 반환합니다.
또한, 예외 처리를 추가하여 안정성을 높였습니다.

### 🏗 작업 내용
- firstMyCdId, lastMyCdId: 유저가 등록한 전체 CD 중에서 첫 번째, 마지막 ID를 반환하도록 변경
- MyCdDatabaseException, MyCdPaginationException 예외 추가 및 적용
- MyCdRepository에 `findFirstByUserIdOrderByIdAsc`, `findFirstByUserIdOrderByIdDesc` 메서드 추가
- 잘못된 커서 값 처리 (`MyCdPaginationException` 적용)

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> #246 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
