### PR TITLE
Fix: MyBook 삭제전, MyBookReview 먼저 삭제

### DIFF
--- a/roome/src/main/java/com/roome/domain/mybook/service/MyBookService.java
+++ b/roome/src/main/java/com/roome/domain/mybook/service/MyBookService.java
@@ -13,6 +13,7 @@ import com.roome.domain.mybook.exception.MyBookDuplicateException;
 import com.roome.domain.mybook.service.request.MyBookCreateRequest;
 import com.roome.domain.mybook.service.response.MyBookResponse;
 import com.roome.domain.mybook.service.response.MyBooksResponse;
+import com.roome.domain.mybookreview.entity.repository.MyBookReviewRepository;
 import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.repository.RoomRepository;
 import com.roome.domain.user.entity.User;
@@ -31,6 +32,7 @@ import static com.roome.global.util.StringUtil.convertStringToList;
 public class MyBookService {
 
     private final MyBookRepository myBookRepository;
+    private final MyBookReviewRepository myBookReviewRepository;
     private final MyBookCountRepository myBookCountRepository;
     private final BookRepository bookRepository;
     private final RoomRepository roomRepository;
@@ -82,6 +84,7 @@ public class MyBookService {
         room.validateOwner(loginUserId);
 
         List<String> ids = convertStringToList(myBookIds);
+        myBookReviewRepository.deleteAllByMyBookIds(ids);
         myBookRepository.deleteAllIn(ids);
         myBookCountRepository.decrease(roomOwnerId, ids.size());
     }

--- a/roome/src/main/java/com/roome/domain/mybookreview/entity/repository/MyBookReviewRepository.java
+++ b/roome/src/main/java/com/roome/domain/mybookreview/entity/repository/MyBookReviewRepository.java
@@ -3,7 +3,10 @@ package com.roome.domain.mybookreview.entity.repository;
 import com.roome.domain.mybookreview.entity.MyBookReview;
 import com.roome.domain.mybookreview.exception.MyBookReviewNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MyBookReviewRepository extends JpaRepository<MyBookReview, Long> {
@@ -19,4 +22,12 @@ public interface MyBookReviewRepository extends JpaRepository<MyBookReview, Long
 
     // 특정 사용자가 작성한 모든 도서 리뷰 삭제
     void deleteAllByUserId(Long userId);
+
+    @Modifying
+    @Query(
+            value = """
+                    delete from MyBookReview mbr where mbr.myBook.id in(:myBookIds)
+                    """
+    )
+    void deleteAllByMyBookIds(List<String> myBookIds);
 }


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
MyBook 삭제 안되는 문제 해결
MyBook과 MyBookReview가 1:1관계인데, MyBookReveiw가 있으면 MyBook이 삭제가 안되고 있던 문제, MyBookReview 먼저 삭제 후 MyBook 삭제

### 🏗 작업 내용
- [ ] MyBookReview 먼저 삭제 후 MyBook 삭제

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
