### PR TITLE
Fix: 방명록 응답 수정 및 가구 응답 수정

### DIFF
--- a/roome/src/main/java/com/roome/domain/book/entity/repository/GenreRepository.java
+++ b/roome/src/main/java/com/roome/domain/book/entity/repository/GenreRepository.java
@@ -2,10 +2,16 @@ package com.roome.domain.book.entity.repository;
 
 import com.roome.domain.book.entity.Genre;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GenreRepository extends JpaRepository<Genre, Long> {
 
     Optional<Genre> findByName(String name);
+
+    @Query("SELECT bg.genre.name FROM BookGenre bg WHERE bg.book.id IN " +
+            "(SELECT mb.book.id FROM MyBook mb WHERE mb.room.id = :roomId)")
+    List<String> findGenresByRoomId(Long roomId);
 }

--- a/roome/src/main/java/com/roome/domain/cd/repository/CdGenreTypeRepository.java
+++ b/roome/src/main/java/com/roome/domain/cd/repository/CdGenreTypeRepository.java
@@ -2,9 +2,15 @@ package com.roome.domain.cd.repository;
 
 import com.roome.domain.cd.entity.CdGenreType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CdGenreTypeRepository extends JpaRepository<CdGenreType, Long> {
   Optional<CdGenreType> findByName(String name);
+
+  @Query("SELECT cg.genreType.name FROM CdGenre cg WHERE cg.cd.id IN " +
+          "(SELECT mc.cd.id FROM MyCd mc WHERE mc.room.id = :roomId)")
+  List<String> findGenresByRoomId(Long roomId);
 }

--- a/roome/src/main/java/com/roome/domain/furniture/dto/FurnitureResponseDto.java
+++ b/roome/src/main/java/com/roome/domain/furniture/dto/FurnitureResponseDto.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -13,6 +15,7 @@ public class FurnitureResponseDto {
     private Boolean isVisible;
     private int level;
     private int maxCapacity;
+    private List<String> topGenres;
 
     public static FurnitureResponseDto from(Furniture furniture) {
         return FurnitureResponseDto.builder()
@@ -20,6 +23,16 @@ public class FurnitureResponseDto {
                 .isVisible(furniture.getIsVisible())
                 .level(furniture.getLevel())
                 .maxCapacity(furniture.getMaxCapacity())
+                .build();
+    }
+
+    public static FurnitureResponseDto from(Furniture furniture, List<String> topGenres) {
+        return FurnitureResponseDto.builder()
+                .furnitureType(furniture.getFurnitureType().name())
+                .isVisible(furniture.getIsVisible())
+                .level(furniture.getLevel())
+                .maxCapacity(furniture.getMaxCapacity())
+                .topGenres(topGenres)
                 .build();
     }
 }

--- a/roome/src/main/java/com/roome/domain/guestbook/controller/MockGuestbookController.java
+++ b/roome/src/main/java/com/roome/domain/guestbook/controller/MockGuestbookController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -23,9 +24,9 @@ public class MockGuestbookController {
     ) {
         List<GuestbookResponseDto> mockGuestbooks = List.of(
                 new GuestbookResponseDto(1L, 123L, "VisitorA", "https://example.com/profileA.jpg",
-                        "방 정말 예쁘네요!", LocalDateTime.parse("2025-02-20T12:00:00"), "하우스메이트"),
+                        "방 정말 예쁘네요!", LocalDate.parse("2025-02-20"), "하우스메이트"),
                 new GuestbookResponseDto(2L, 124L, "VisitorB", "https://example.com/profileB.jpg",
-                        "분위기가 너무 좋아요!", LocalDateTime.parse("2025-02-20T12:10:00"), "지나가던 나그네")
+                        "분위기가 너무 좋아요!", LocalDate.parse("2025-02-20"), "지나가던 나그네")
 
         );
 
@@ -42,7 +43,7 @@ public class MockGuestbookController {
     ) {
         GuestbookResponseDto mockResponse = new GuestbookResponseDto(
                 3L, 125L, "VisitorC", "https://example.com/profileC.jpg",
-                requestDto.getMessage(), LocalDateTime.parse("2025-02-20T12:30:00"), "지나가던 나그네"
+                requestDto.getMessage(), LocalDate.parse("2025-02-20"), "지나가던 나그네"
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(mockResponse);

--- a/roome/src/main/java/com/roome/domain/guestbook/dto/GuestbookResponseDto.java
+++ b/roome/src/main/java/com/roome/domain/guestbook/dto/GuestbookResponseDto.java
@@ -31,4 +31,16 @@ public class GuestbookResponseDto {
                 .relation(guestbook.getRelation().name())
                 .build();
     }
+
+    public static GuestbookResponseDto from(Guestbook guestbook, boolean isHousemate) {
+        return GuestbookResponseDto.builder()
+                .guestbookId(guestbook.getGuestbookId())
+                .userId(guestbook.getUser().getId())
+                .nickname(guestbook.getUser().getNickname())
+                .profileImage(guestbook.getUser().getProfileImage())
+                .message(guestbook.getMessage())
+                .createdAt(guestbook.getCreatedAt().toLocalDate()) // YYYY-MM-DD만 반환
+                .relation(isHousemate ? "하우스메이트" : guestbook.getRelation().name()) // 하우스메이트 여부 반영
+                .build();
+    }
 }

--- a/roome/src/main/java/com/roome/domain/guestbook/dto/GuestbookResponseDto.java
+++ b/roome/src/main/java/com/roome/domain/guestbook/dto/GuestbookResponseDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -16,7 +17,7 @@ public class GuestbookResponseDto {
     private String nickname;
     private String profileImage;
     private String message;
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
     private String relation;
 
     public static GuestbookResponseDto from(Guestbook guestbook) {
@@ -26,7 +27,7 @@ public class GuestbookResponseDto {
                 .nickname(guestbook.getUser().getNickname())
                 .profileImage(guestbook.getUser().getProfileImage())
                 .message(guestbook.getMessage())
-                .createdAt(guestbook.getCreatedAt())
+                .createdAt(guestbook.getCreatedAt().toLocalDate())
                 .relation(guestbook.getRelation().name())
                 .build();
     }

--- a/roome/src/main/java/com/roome/domain/room/controller/MockRoomController.java
+++ b/roome/src/main/java/com/roome/domain/room/controller/MockRoomController.java
@@ -24,6 +24,15 @@ import java.util.Map;
 @Tag(name = "Mock - Room API", description = "방 조회/테마 업데이트/가구 활성화 및 비활성화")
 public class MockRoomController {
 
+    private List<String> getMockTop3BookGenres() {
+        return List.of("Fantasy", "Mystery", "Science Fiction");
+    }
+
+    private List<String> getMockTop3CdGenres() {
+        return List.of("Rock", "Pop", "Jazz");
+    }
+
+
     @Operation(summary = "Mock - 방 조회", description = "주어진 방 ID에 해당하는 방 정보 조회")
     @GetMapping("/{roomId}")
     public ResponseEntity<RoomResponseDto> getRoom(
@@ -74,10 +83,16 @@ public class MockRoomController {
             return ResponseEntity.badRequest().body(null);
         }
 
+        List<String> topGenres = switch (furnitureType) {
+            case BOOKSHELF -> getMockTop3BookGenres();
+            case CD_RACK -> getMockTop3CdGenres();
+            default -> List.of(); // 기타 가구는 장르 없음
+        };
+
         // 가구 리스트에서 해당 타입 찾기
         List<FurnitureResponseDto> furnitureList = List.of(
-                new FurnitureResponseDto("BOOKSHELF", true, 3, FurnitureCapacity.getCapacity(FurnitureType.BOOKSHELF, 3)),
-                new FurnitureResponseDto("CD_RACK", false, 1, FurnitureCapacity.getCapacity(FurnitureType.CD_RACK, 1))
+                new FurnitureResponseDto("BOOKSHELF", true, 3, FurnitureCapacity.getCapacity(FurnitureType.BOOKSHELF, 3), getMockTop3BookGenres()),
+                new FurnitureResponseDto("CD_RACK", false, 1, FurnitureCapacity.getCapacity(FurnitureType.CD_RACK, 1), getMockTop3CdGenres())
         );
 
         FurnitureResponseDto targetFurniture = furnitureList.stream()
@@ -94,7 +109,8 @@ public class MockRoomController {
                 targetFurniture.getFurnitureType(),
                 !targetFurniture.getIsVisible(),
                 targetFurniture.getLevel(),
-                targetFurniture.getMaxCapacity()
+                targetFurniture.getMaxCapacity(),
+                topGenres
         );
 
         ToggleFurnitureResponseDto responseDto = new ToggleFurnitureResponseDto(roomId, updatedFurniture);
@@ -108,8 +124,8 @@ public class MockRoomController {
                 .theme(theme)
                 .createdAt(LocalDateTime.now())
                 .furnitures(List.of(
-                        new FurnitureResponseDto("BOOKSHELF", true, 3, FurnitureCapacity.getCapacity(FurnitureType.BOOKSHELF, 3)),
-                        new FurnitureResponseDto("CD_RACK", false, 1, FurnitureCapacity.getCapacity(FurnitureType.CD_RACK, 1))
+                        new FurnitureResponseDto("BOOKSHELF", true, 3, FurnitureCapacity.getCapacity(FurnitureType.BOOKSHELF, 3), getMockTop3BookGenres()),
+                        new FurnitureResponseDto("CD_RACK", false, 1, FurnitureCapacity.getCapacity(FurnitureType.CD_RACK, 1), getMockTop3CdGenres())
                 ))
                 .storageLimits(new StorageLimitsDto(100, 50))
                 .userStorage(new UserStorageDto(25L, 10L, 5L, 7L))

--- a/roome/src/main/java/com/roome/domain/room/controller/MockRoomController.java
+++ b/roome/src/main/java/com/roome/domain/room/controller/MockRoomController.java
@@ -86,7 +86,6 @@ public class MockRoomController {
         List<String> topGenres = switch (furnitureType) {
             case BOOKSHELF -> getMockTop3BookGenres();
             case CD_RACK -> getMockTop3CdGenres();
-            default -> List.of(); // 기타 가구는 장르 없음
         };
 
         // 가구 리스트에서 해당 타입 찾기

--- a/roome/src/main/java/com/roome/domain/room/dto/RoomResponseDto.java
+++ b/roome/src/main/java/com/roome/domain/room/dto/RoomResponseDto.java
@@ -22,6 +22,8 @@ public class RoomResponseDto {
     private List<FurnitureResponseDto> furnitures;
     private StorageLimitsDto storageLimits;
     private UserStorageDto userStorage;
+    private List<String> topBookGenres;
+    private List<String> topCdGenres;
 
     public static RoomResponseDto from(Room room, Long savedMusic, Long savedBooks, Long writtenReviews, Long writtenMusicLogs) {
         return RoomResponseDto.builder()
@@ -35,6 +37,23 @@ public class RoomResponseDto {
                         : Collections.emptyList())
                 .storageLimits(StorageLimitsDto.from(room))
                 .userStorage(UserStorageDto.from(savedMusic, savedBooks, writtenReviews, writtenMusicLogs))
+                .build();
+    }
+
+    public static RoomResponseDto from(Room room, Long savedMusic, Long savedBooks,
+                                       Long writtenReviews, Long writtenMusicLogs,
+                                       List<String> topBookGenres, List<String> topCdGenres) {
+        return RoomResponseDto.builder()
+                .roomId(room.getId())
+                .userId(room.getUser().getId())
+                .theme(room.getTheme().name())
+                .furnitures(room.getFurnitures() != null
+                        ? room.getFurnitures().stream().map(FurnitureResponseDto::from).collect(Collectors.toList())
+                        : Collections.emptyList())
+                .storageLimits(StorageLimitsDto.from(room))
+                .userStorage(UserStorageDto.from(savedMusic, savedBooks, writtenReviews, writtenMusicLogs))
+                .topBookGenres(topBookGenres)
+                .topCdGenres(topCdGenres)
                 .build();
     }
 }

--- a/roome/src/main/java/com/roome/domain/room/service/RoomService.java
+++ b/roome/src/main/java/com/roome/domain/room/service/RoomService.java
@@ -231,8 +231,13 @@ public class RoomService {
         boolean newVisibility = !furniture.getIsVisible();
         furniture.setVisible(newVisibility);
 
-        log.info("가구 상태 변경 완료: 방(roomId={}), 가구({}), 새 상태={}", roomId, furnitureType, newVisibility);
-        return FurnitureResponseDto.from(furniture);
+        List<String> topGenres = switch (furnitureType) {
+            case BOOKSHELF -> getTop3BookGenres(roomId);
+            case CD_RACK -> getTop3CdGenres(roomId);
+        };
+
+        log.info("가구 상태 변경 완료: 방(roomId={}), 가구({}), 새 상태={}, Top3 장르={}", roomId, furnitureType, newVisibility, topGenres);
+        return FurnitureResponseDto.from(furniture, topGenres);
     }
 
 


### PR DESCRIPTION
### ✅ PR 설명
방명록 응답 수정 및 가구 응답 수정했습니다.

### 🏗 작업 내용
- [ ] 방명록 작성 시 바뀐 관계 반영되도록 응답 수정 (하우스메이트 or 지나가는 나그네)
- [ ] 방명록 조회 시 바뀐 관계 반영되도록 응답 수정 (하우스메이트 or 지나가는 나그네)
- [ ] 방 조회 시 CD 랙에 해당하는 장르 3개와 책꽂이에 해당하는 장르 3개 함께 응답하도록 수정
- [ ] 가구 토글 시 토글한 가구에 해당하는 장르 3개도 함께 응답하도록 수정

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
