### PR TITLE
Fix: 방 조회 시 닉네임이랑 생성 날짜도 응답되도록 수정

### DIFF
--- a/roome/src/main/java/com/roome/domain/room/dto/RoomResponseDto.java
+++ b/roome/src/main/java/com/roome/domain/room/dto/RoomResponseDto.java
@@ -47,6 +47,8 @@ public class RoomResponseDto {
                 .roomId(room.getId())
                 .userId(room.getUser().getId())
                 .theme(room.getTheme().name())
+                .nickname(room.getUser().getNickname())
+                .createdAt(room.getCreatedAt())
                 .furnitures(room.getFurnitures() != null
                         ? room.getFurnitures().stream().map(FurnitureResponseDto::from).collect(Collectors.toList())
                         : Collections.emptyList())


### PR DESCRIPTION
### ✅ PR 설명
방 조회 시 닉네임이랑 생성 날짜도 응답되도록 수정했습니다.

### 🏗 작업 내용
- [ ] 방 조회 시 닉네임도 응답
- [ ] 방 조회 시 생성 날짜도 응답

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
