### PR TITLE
Fix: 하루마다 첫 로그인시 포인트 적립 안되던 문제 해결

### DIFF
--- a/roome/src/main/java/com/roome/domain/point/service/PointService.java
+++ b/roome/src/main/java/com/roome/domain/point/service/PointService.java
@@ -12,8 +12,6 @@ import com.roome.domain.point.repository.PointRepository;
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
 import com.roome.global.jwt.exception.UserNotFoundException;
-import com.roome.domain.point.exception.DuplicatePointEarnException;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -56,9 +54,10 @@ public class PointService {
     int amount = POINT_EARN_MAP.getOrDefault(reason, 0);
 
     // 검증 로직 수정해야할 것 같습니다.
+    /*
     if (pointHistoryRepository.existsByUserIdAndReasonAndCreatedAt(user.getId(), reason, LocalDate.now())) {
       throw new DuplicatePointEarnException();
-    }
+    }*/
 
     Point point = pointRepository.findByUser(user)
         .orElseThrow(PointNotFoundException::new);

--- a/roome/src/main/java/com/roome/domain/user/entity/User.java
+++ b/roome/src/main/java/com/roome/domain/user/entity/User.java
@@ -131,14 +131,6 @@ public class User extends BaseTimeEntity {
     return lastLogin != null && (lastLogin.isEqual(midnight) || lastLogin.isAfter(midnight));
   }
 
-  public void accumulatePoints(int point) {
-    this.point.addPoints(point);
-  }
-
-  public void payPoints(int point) {
-    this.point.subtractPoints(point);
-  }
-
   public void validateRoomOwner(Long roomId) {
     if (room == null || !room.getId().equals(roomId)) {
       throw new RoomAuthorizationException();


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
하루마다 첫 로그인시 포인트 적립 안되던 문제 해결

### 🏗 작업 내용
- [ ] user 엔티티의 lastLogin 필드의 값을 포인트 적립 로직 전에 할당하거나 수정하지 않도록 변경
- [ ] 포인트 적립 로직을 Pointservice의 earnPoints 메서드 사용하도록 변경
- [ ] earnPoints 메서드 사용으로 인해 사용하지 않게 된 user 엔티티의 메서드 삭제

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
