### PR TITLE
Fix: 재발급 api 500 에러 수정

### DIFF
--- a/roome/src/main/java/com/roome/global/jwt/controller/ReissueController.java
+++ b/roome/src/main/java/com/roome/global/jwt/controller/ReissueController.java
@@ -4,6 +4,7 @@ import com.roome.domain.auth.dto.response.MessageResponse;
 import com.roome.global.jwt.dto.TokenReissueRequest;
 import com.roome.global.jwt.dto.TokenResponse;
 import com.roome.global.jwt.exception.InvalidJwtTokenException;
+import com.roome.global.jwt.exception.InvalidRefreshTokenException;
 import com.roome.global.jwt.exception.UserNotFoundException;
 import com.roome.global.jwt.service.JwtTokenProvider;
 import com.roome.global.jwt.service.TokenService;
@@ -11,6 +12,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
@@ -42,59 +45,72 @@ public class ReissueController {
   @PostMapping("/reissue-token")
   public ResponseEntity<?> reissueToken(
       @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-      @RequestBody TokenReissueRequest request) {
+      @RequestBody(required = false) TokenReissueRequest request,
+      HttpServletRequest servletRequest) {
+
     try {
+      // 1. 요청 객체 검증
+      if (request == null) {
+        log.warn("요청 객체가 null입니다.");
+        return ResponseEntity.badRequest().body(new MessageResponse("요청이 올바르지 않습니다. 다시 로그인해 주세요."));
+      }
+
+      // 2. 리프레시 토큰 추출
       String refreshToken = request.getRefreshToken();
+      log.debug("요청에서 받은 리프레시 토큰: {}", refreshToken != null ? "있음" : "없음");
 
-      // 리프레시 토큰이 없는 경우
+      // 3. 요청 바디에 리프레시 토큰이 없는 경우 쿠키에서 확인
       if (refreshToken == null || refreshToken.isBlank()) {
-        return ResponseEntity.badRequest().body(new MessageResponse("리프레시 토큰이 필요합니다."));
-      }
-
-      // 리프레시 토큰 검증
-      if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
-        return ResponseEntity.badRequest().body(new MessageResponse("유효하지 않은 리프레시 토큰입니다."));
-      }
-
-      // 현재 액세스 토큰 확인
-      String currentAccessToken = null;
-      if (StringUtils.hasText(authorizationHeader) && authorizationHeader.startsWith("Bearer ")) {
-        currentAccessToken = authorizationHeader.substring(7);
-      }
-
-      // 액세스 토큰 검증 및 유효시간 확인
-      boolean accessTokenValid = false;
-      long remainingTime = 0;
-
-      if (currentAccessToken != null) {
-        try {
-          accessTokenValid = jwtTokenProvider.validateAccessToken(currentAccessToken);
-          if (accessTokenValid) {
-            remainingTime = jwtTokenProvider.getTokenTimeToLive(currentAccessToken);
+        Cookie[] cookies = servletRequest.getCookies();
+        if (cookies != null) {
+          for (Cookie cookie : cookies) {
+            if ("refresh_token".equals(cookie.getName())) {
+              refreshToken = cookie.getValue();
+              log.debug("쿠키에서 리프레시 토큰 발견");
+              break;
+            }
           }
-        } catch (InvalidJwtTokenException e) {
-          // 토큰이 만료된 경우
-          log.info("액세스 토큰이 만료되었습니다. 새 토큰을 발급합니다.");
-        } catch (Exception e) {
-          // 기타 예외 처리
-          log.warn("액세스 토큰 검증 중 오류 발생: {}", e.getMessage());
         }
       }
 
-      // 액세스 토큰이 유효하고 만료까지 5분 이상 남은 경우
+      // 4. 여전히 리프레시 토큰이 없는 경우
+      if (refreshToken == null || refreshToken.isBlank()) {
+        log.warn("리프레시 토큰이 없음 (바디와 쿠키 모두 확인)");
+        return ResponseEntity.badRequest()
+            .body(new MessageResponse("Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."));
+      }
+
+      // 5. 리프레시 토큰 검증
+      if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+        log.warn("유효하지 않은 리프레시 토큰");
+        return ResponseEntity.badRequest()
+            .body(new MessageResponse("Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."));
+      }
+
+      // 6. 현재 액세스 토큰 확인 및 검증
+      String currentAccessToken = extractAccessToken(authorizationHeader);
+      TokenValidationResult validation = validateCurrentAccessToken(currentAccessToken);
+
+      // 7. 액세스 토큰이 유효하고 만료까지 5분 이상 남은 경우
       final long FIVE_MINUTES_IN_MILLIS = 5 * 60 * 1000;
-      if (accessTokenValid && remainingTime > FIVE_MINUTES_IN_MILLIS) {
-        log.info("액세스 토큰이 아직 유효함 (남은 시간: {}ms)", remainingTime);
+      if (validation.valid && validation.remainingTime > FIVE_MINUTES_IN_MILLIS) {
+        log.info("액세스 토큰이 아직 유효함 (남은 시간: {}ms)", validation.remainingTime);
         return ResponseEntity.badRequest()
             .body(new MessageResponse("액세스 토큰이 아직 유효합니다. 만료 임박 시 재요청하세요."));
       }
 
-      // 액세스 토큰 재발급
+      // 8. 액세스 토큰 재발급
       String accessToken = tokenService.reissueAccessToken(refreshToken);
+
+      // 9. 성공 응답 반환
       return ResponseEntity.ok(new TokenResponse(accessToken, "Bearer",
           jwtTokenProvider.getAccessTokenExpirationTime() / 1000 // 초 단위로 변환
       ));
 
+    } catch (InvalidRefreshTokenException e) {
+      log.warn("리프레시 토큰이 유효하지 않음: {}", e.getMessage());
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+          .body(new MessageResponse("Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."));
     } catch (UserNotFoundException e) {
       log.warn("사용자를 찾을 수 없음: {}", e.getMessage());
       return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -106,7 +122,51 @@ public class ReissueController {
     } catch (Exception e) {
       String errorMsg = String.format("토큰 재발급 중 오류 발생: %s", e.getMessage());
       log.error(errorMsg, e);
-      return ResponseEntity.internalServerError().body(new MessageResponse(errorMsg));
+      return ResponseEntity.internalServerError()
+          .body(new MessageResponse("서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."));
     }
+  }
+
+  // 액세스 토큰 추출
+  private String extractAccessToken(String authorizationHeader) {
+    if (StringUtils.hasText(authorizationHeader) && authorizationHeader.startsWith("Bearer ")) {
+      return authorizationHeader.substring(7);
+    }
+    return null;
+  }
+
+  // 액세스 토큰 검증 결과 클래스
+  private static class TokenValidationResult {
+
+    final boolean valid;
+    final long remainingTime;
+
+    TokenValidationResult(boolean valid, long remainingTime) {
+      this.valid = valid;
+      this.remainingTime = remainingTime;
+    }
+  }
+
+  // 현재 액세스 토큰 검증
+  private TokenValidationResult validateCurrentAccessToken(String accessToken) {
+    if (accessToken == null) {
+      return new TokenValidationResult(false, 0);
+    }
+
+    boolean valid = false;
+    long remainingTime = 0;
+
+    try {
+      valid = jwtTokenProvider.validateAccessToken(accessToken);
+      if (valid) {
+        remainingTime = jwtTokenProvider.getTokenTimeToLive(accessToken);
+      }
+    } catch (InvalidJwtTokenException e) {
+      log.info("액세스 토큰이 만료되었습니다. 새 토큰을 발급합니다.");
+    } catch (Exception e) {
+      log.warn("액세스 토큰 검증 중 오류 발생: {}", e.getMessage());
+    }
+
+    return new TokenValidationResult(valid, remainingTime);
   }
 }

--- a/roome/src/main/java/com/roome/global/jwt/dto/TokenReissueRequest.java
+++ b/roome/src/main/java/com/roome/global/jwt/dto/TokenReissueRequest.java
@@ -1,11 +1,19 @@
 package com.roome.global.jwt.dto;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-@Getter
-@Setter
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TokenReissueRequest {
 
   private String refreshToken;
+
+  public String getRefreshToken() {
+    return refreshToken != null ? refreshToken : "";
+  }
 }

--- a/roome/src/main/java/com/roome/global/service/RedisService.java
+++ b/roome/src/main/java/com/roome/global/service/RedisService.java
@@ -34,8 +34,6 @@ public class RedisService {
   }
 
   // Refresh Token 조회
-  @Retryable(value = {
-      RedisConnectionFailureException.class}, maxAttempts = 2, backoff = @Backoff(delay = 500))
   public String getRefreshToken(String userId) {
     String key = REFRESH_TOKEN_PREFIX + userId;
     try {
@@ -80,8 +78,6 @@ public class RedisService {
   }
 
   // 토큰이 블랙리스트에 있는지 확인
-  @Retryable(value = {
-      RedisConnectionFailureException.class}, maxAttempts = 2, backoff = @Backoff(delay = 300))
   public boolean isBlacklisted(String accessToken) {
     String key = BLACKLIST_PREFIX + accessToken;
     try {

--- a/roome/src/main/resources/application.yml
+++ b/roome/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
             client-name: google
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: https://desqb38rc2v50.cloudfront.net/oauth/callback/{registrationId}
+            redirect-uri: "{baseUrl}/oauth/callback/{registrationId}"
             authorization-grant-type: authorization_code
             scope:
               - email


### PR DESCRIPTION
## 📌 Fix: 재발급 api 500 에러 수정

### ✅ PR 설명
프론트 측에서 재발급 api 요청 시 간헐적으로 발생하던 500 에러를 수정하였습니다. 

### 🏗 작업 내용
- [ ] TODO 1 (어떤 기능을 개발했는지)
- [ ] TODO 2 (관련 API가 있다면 명시)
- [ ] TODO 3 (테스트 여부 등)

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.
✅ 리다이렉트 주소 변경으로 구글 로그인 동작 확인
![스크린샷 2025-03-04 21.22.05.png](attachment:b9d63db9-dcf0-46a2-b722-ccb7f1facb11:스크린샷_2025-03-04_21.22.05.png)

✅ 요청 바디에 리프레시 토큰이 없는 경우 쿠키에서 확인 후 재발급 동작 확인
![스크린샷 2025-03-04 21.14.03.png](attachment:3ecca05a-b08d-42e3-9ea2-ed68019d12ff:스크린샷_2025-03-04_21.14.03.png)

✅ 액세스 토큰이 유효한 경우(5분 이상)
![스크린샷 2025-03-04 21.29.36.png](attachment:7cccd003-4c23-405c-9fd3-6c0e9c818985:스크린샷_2025-03-04_21.29.36.png)

✅ 리프레시 토큰을 찾을 수 없는 경우
![스크린샷 2025-03-04 21.30.10.png](attachment:aa5b9afe-dc4b-4de6-af9f-f977108dc2f2:스크린샷_2025-03-04_21.30.10.png)

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
