### PR TITLE
Feat: 등록 도서 목록조회 API에 keyword 추가, 제목, 저자, 출판사에 대한 검색 가능

### DIFF
--- a/roome/src/main/java/com/roome/domain/mybook/controller/MyBookController.java
+++ b/roome/src/main/java/com/roome/domain/mybook/controller/MyBookController.java
@@ -36,14 +36,15 @@ public class MyBookController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "등록 도서 목록 조회", description = "등록 도서의 목록을 무한 스크롤 방식으로 조회할 수 있다.")
+    @Operation(summary = "등록 도서 목록 조회", description = "등록 도서의 목록을 무한 스크롤 방식으로 조회할 수 있다. 제목, 출판사, 저자에 대해 검색할 수 있다.")
     @GetMapping("/api/mybooks")
     public ResponseEntity<MyBooksResponse> readAll(
             @RequestParam("userId") Long userId,
             @RequestParam("pageSize") Long pageSize,
-            @RequestParam(value = "lastMyBookId", required = false) Long lastMyBookId
+            @RequestParam(value = "lastMyBookId", required = false) Long lastMyBookId,
+            @RequestParam(value = "keyword", required = false) String keyword
     ) {
-        MyBooksResponse response = myBookService.readAll(userId, pageSize, lastMyBookId);
+        MyBooksResponse response = myBookService.readAll(userId, pageSize, lastMyBookId, keyword);
         return ResponseEntity.ok(response);
     }
 

--- a/roome/src/main/java/com/roome/domain/mybook/entity/repository/MyBookRepository.java
+++ b/roome/src/main/java/com/roome/domain/mybook/entity/repository/MyBookRepository.java
@@ -25,12 +25,17 @@ public interface MyBookRepository extends JpaRepository<MyBook, Long> {
                     from MyBook mb
                     join fetch mb.book
                     where mb.user.id = :roomOwnerId
+                    and (:keyword is null or
+                    lower(mb.book.title) like concat('%', :keyword, '%')
+                    or lower(mb.book.author) like concat('%', :keyword, '%')
+                    or lower(mb.book.publisher) like concat('%', :keyword, '%'))
                     order by mb.id desc limit :limit
                     """
     )
     List<MyBook> findAll(
             @Param("roomOwnerId") Long roomOwnerId,
-            @Param("limit") Long limit
+            @Param("limit") Long limit,
+            @Param("keyword") String keyword
     );
 
     @Query(
@@ -39,13 +44,18 @@ public interface MyBookRepository extends JpaRepository<MyBook, Long> {
                     from MyBook mb
                     join fetch mb.book
                     where mb.user.id = :roomOwnerId and mb.id < :lastMyBookId
+                    and (:keyword is null or
+                    lower(mb.book.title) like concat('%', :keyword, '%')
+                    or lower(mb.book.author) like concat('%', :keyword, '%')
+                    or lower(mb.book.publisher) like concat('%', :keyword, '%'))
                     order by mb.id desc limit :limit
                     """
     )
     List<MyBook> findAll(
             @Param("roomOwnerId") Long roomOwnerId,
             @Param("limit") Long limit,
-            @Param("lastMyBookId") Long lastMyBookId
+            @Param("lastMyBookId") Long lastMyBookId,
+            @Param("keyword") String keyword
     );
 
     @Modifying

--- a/roome/src/main/java/com/roome/domain/mybook/service/MyBookService.java
+++ b/roome/src/main/java/com/roome/domain/mybook/service/MyBookService.java
@@ -77,10 +77,11 @@ public class MyBookService {
         );
     }
 
-    public MyBooksResponse readAll(Long roomOwnerId, Long pageSize, Long lastMyBookId) {
+    public MyBooksResponse readAll(Long roomOwnerId, Long pageSize, Long lastMyBookId, String keyword) {
+        keyword = keyword == null || keyword.isBlank() ? null : keyword.toLowerCase();
         List<MyBook> myBooks = lastMyBookId == null ?
-                myBookRepository.findAll(roomOwnerId, pageSize) :
-                myBookRepository.findAll(roomOwnerId, pageSize, lastMyBookId);
+                myBookRepository.findAll(roomOwnerId, pageSize, keyword) :
+                myBookRepository.findAll(roomOwnerId, pageSize, lastMyBookId, keyword);
         return MyBooksResponse.of(myBooks, count(roomOwnerId));
     }
 


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
등록 도서 목록조회 API에 keyword 추가, 제목, 저자, 출판사에 대한 검색 가능

### 🏗 작업 내용
- [ ] 등록 도서 목록조회 API 쿼리 파라미터에 keyword 추가
- [ ] 목록조회 쿼리 수정, 제목, 저자, 출판사에 대해 keyword로 검색

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
