### PR TITLE
Refactor: 주간 랭킹 보상 시스템 개선

### DIFF
--- a/roome/src/main/java/com/roome/domain/point/entity/PointReason.java
+++ b/roome/src/main/java/com/roome/domain/point/entity/PointReason.java
@@ -1,6 +1,7 @@
 package com.roome.domain.point.entity;
 
 import com.roome.domain.furniture.exception.BookshelfMaxLevelException;
+import com.roome.domain.furniture.exception.CdRackMaxLevelException;
 
 public enum PointReason {
   // 포인트 적립
@@ -32,5 +33,15 @@ public enum PointReason {
       return BOOK_UNLOCK_LV3;
     }
     throw new BookshelfMaxLevelException();
+  }
+
+  public static PointReason getCdRackUpgradeReason(int level) {
+    if (level == 1) {
+      return CD_UNLOCK_LV2;
+    }
+    if (level == 2) {
+      return CD_UNLOCK_LV3;
+    }
+    throw new CdRackMaxLevelException();
   }
 }

--- a/roome/src/main/java/com/roome/domain/point/entity/PointReason.java
+++ b/roome/src/main/java/com/roome/domain/point/entity/PointReason.java
@@ -1,13 +1,15 @@
 package com.roome.domain.point.entity;
 
 import com.roome.domain.furniture.exception.BookshelfMaxLevelException;
-import com.roome.domain.furniture.exception.CdRackMaxLevelException;
 
 public enum PointReason {
   // 포인트 적립
   GUESTBOOK_REWARD,  // 방명록 작성 보상 (+10P, 1일 1회)
   FIRST_COME_EVENT,  // 선착순 이벤트 보상 (랜덤 지급)
   DAILY_ATTENDANCE,  // 출석 체크 보상 (하루 1회 랜덤 지급)
+  RANK_1,            // 주간 랭킹 1등 (100P)
+  RANK_2,            // 주간 랭킹 2등 (70P)
+  RANK_3,            // 주간 랭킹 3등 (50P)
 
   // 포인트 사용
   THEME_PURCHASE,    // 테마 구매
@@ -30,15 +32,5 @@ public enum PointReason {
       return BOOK_UNLOCK_LV3;
     }
     throw new BookshelfMaxLevelException();
-  }
-
-  public static PointReason getCdRackUpgradeReason(int level) {
-    if (level == 1) {
-      return CD_UNLOCK_LV2;
-    }
-    if (level == 2) {
-      return CD_UNLOCK_LV3;
-    }
-    throw new CdRackMaxLevelException();
   }
 }

--- a/roome/src/test/java/com/roome/domain/rank/service/RankingSchedulerTest.java
+++ b/roome/src/test/java/com/roome/domain/rank/service/RankingSchedulerTest.java
@@ -1,0 +1,119 @@
+package com.roome.domain.rank.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.roome.domain.point.entity.Point;
+import com.roome.domain.point.entity.PointHistory;
+import com.roome.domain.point.repository.PointHistoryRepository;
+import com.roome.domain.point.repository.PointRepository;
+import com.roome.domain.rank.repository.UserActivityRepository;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+@ExtendWith(MockitoExtension.class)
+public class RankingSchedulerTest {
+
+  @Mock
+  private RedisTemplate<String, Object> redisTemplate;
+
+  @Mock
+  private ZSetOperations<String, Object> zSetOperations;
+
+  @Mock
+  private UserActivityRepository userActivityRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PointRepository pointRepository;
+
+  @Mock
+  private PointHistoryRepository pointHistoryRepository;
+
+  @InjectMocks
+  private RankingScheduler rankingScheduler;
+
+  @BeforeEach
+  void setUp() {
+    when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+  }
+
+  @DisplayName("주간 랭킹 보상 지급 테스트")
+  @Test
+  void awardWeeklyPointsTest() {
+    // Given
+    Set<ZSetOperations.TypedTuple<Object>> topRankers = new LinkedHashSet<>();
+
+    // 1등 모킹
+    ZSetOperations.TypedTuple<Object> firstRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
+    when(firstRanker.getValue()).thenReturn("1");
+    when(firstRanker.getScore()).thenReturn(100.0);
+    topRankers.add(firstRanker);
+
+    // 2등 모킹
+    ZSetOperations.TypedTuple<Object> secondRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
+    when(secondRanker.getValue()).thenReturn("2");
+    when(secondRanker.getScore()).thenReturn(80.0);
+    topRankers.add(secondRanker);
+
+    // 3등 모킹
+    ZSetOperations.TypedTuple<Object> thirdRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
+    when(thirdRanker.getValue()).thenReturn("3");
+    when(thirdRanker.getScore()).thenReturn(70.0);
+    topRankers.add(thirdRanker);
+
+    when(zSetOperations.reverseRangeWithScores("user:ranking", 0, 2)).thenReturn(topRankers);
+
+    // 유저 정보 모킹
+    User user1 = Mockito.mock(User.class);
+    User user2 = Mockito.mock(User.class);
+    User user3 = Mockito.mock(User.class);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user1));
+    when(userRepository.findById(2L)).thenReturn(Optional.of(user2));
+    when(userRepository.findById(3L)).thenReturn(Optional.of(user3));
+
+    // 포인트 정보 모킹
+    Point point1 = Mockito.mock(Point.class);
+    Point point2 = Mockito.mock(Point.class);
+    Point point3 = Mockito.mock(Point.class);
+
+    when(pointRepository.findByUser(user1)).thenReturn(Optional.of(point1));
+    when(pointRepository.findByUser(user2)).thenReturn(Optional.of(point2));
+    when(pointRepository.findByUser(user3)).thenReturn(Optional.of(point3));
+
+    // When
+    rankingScheduler.awardWeeklyPoints();
+
+    // Then
+    verify(point1).addPoints(100);
+    verify(point2).addPoints(70);
+    verify(point3).addPoints(50);
+
+    verify(pointRepository, times(3)).save(any(Point.class));
+    verify(pointHistoryRepository, times(3)).save(any(PointHistory.class));
+
+    verify(userActivityRepository).deleteAllByCreatedAtBefore(any(LocalDateTime.class));
+
+    // redisTemplate.delete는 총 2번 호출됨 (awardWeeklyPoints와 updateRanking에서 각각)
+    verify(redisTemplate, times(2)).delete("user:ranking");
+  }
+}


### PR DESCRIPTION
## 📌 Refactor: 주간 랭킹 보상 시스템 개선

### ✅ PR 설명
Point 도메인을 활용하도록 랭킹 보상 지급 로직을 수정했습니다.

### 🏗 작업 내용
- [ ] PointReason enum에 랭킹 관련 상수 추가
- [ ] RankingScheduler에서 포인트 히스토리 기록 로직 추가
- [ ] 포인트 지급 단위 테스트 추가

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.
<img width="682" alt="스크린샷 2025-03-05 10 32 22" src="https://github.com/user-attachments/assets/28f5d602-c879-4a02-8933-cb859ffccb47" />

### 🔗 관련 이슈 (선택)
> #275

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
