### PR TITLE
Feat: 선착순 이벤트 상태 관리 방식 개선 및 조회 기능 추가 

### DIFF
--- a/roome/src/main/java/com/roome/domain/event/controller/FirstComeEventController.java
+++ b/roome/src/main/java/com/roome/domain/event/controller/FirstComeEventController.java
@@ -4,12 +4,15 @@ import com.roome.domain.event.dto.FirstComeEventResponse;
 import com.roome.domain.event.entity.FirstComeEvent;
 import com.roome.domain.event.service.FirstComeEventService;
 import com.roome.global.auth.AuthenticatedUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "선착순 이벤트 API", description = "선착순 이벤트 관련 API")
 @RestController
 @RequestMapping("/api/events")
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ public class FirstComeEventController {
 
   private final FirstComeEventService firstComeEventService;
 
+  @Operation(summary = "선착순 이벤트 참여", description = "특정 이벤트에 참여한다.")
   @PostMapping("/{eventId}/join")
   public ResponseEntity<Void> joinEvent(
       @AuthenticatedUser Long userId,
@@ -25,6 +29,7 @@ public class FirstComeEventController {
     return ResponseEntity.noContent().build(); // 204 No Content 반환
   }
 
+  @Operation(summary = "진행 중인 이벤트 조회", description = "현재 진행 중인 선착순 이벤트 정보를 반환한다.")
   @GetMapping("/ongoing")
   public ResponseEntity<FirstComeEventResponse> getOngoingEvent() {
     FirstComeEvent event = firstComeEventService.getOngoingEvent();

--- a/roome/src/main/java/com/roome/domain/event/controller/FirstComeEventController.java
+++ b/roome/src/main/java/com/roome/domain/event/controller/FirstComeEventController.java
@@ -1,13 +1,14 @@
 package com.roome.domain.event.controller;
 
+import com.roome.domain.event.dto.FirstComeEventResponse;
+import com.roome.domain.event.entity.FirstComeEvent;
 import com.roome.domain.event.service.FirstComeEventService;
 import com.roome.global.auth.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/events")
@@ -17,8 +18,17 @@ public class FirstComeEventController {
   private final FirstComeEventService firstComeEventService;
 
   @PostMapping("/{eventId}/join")
-  public ResponseEntity<String> joinEvent(@AuthenticatedUser Long userId, @PathVariable Long eventId) {
+  public ResponseEntity<Void> joinEvent(
+      @AuthenticatedUser Long userId,
+      @PathVariable Long eventId) {
     firstComeEventService.joinEvent(userId, eventId);
-    return ResponseEntity.ok("이벤트 참여 성공!");
+    return ResponseEntity.noContent().build(); // 204 No Content 반환
   }
+
+  @GetMapping("/ongoing")
+  public ResponseEntity<FirstComeEventResponse> getOngoingEvent() {
+    FirstComeEvent event = firstComeEventService.getOngoingEvent();
+    return ResponseEntity.ok(FirstComeEventResponse.fromEntity(event));
+  }
+
 }

--- a/roome/src/main/java/com/roome/domain/event/dto/FirstComeEventResponse.java
+++ b/roome/src/main/java/com/roome/domain/event/dto/FirstComeEventResponse.java
@@ -1,0 +1,27 @@
+package com.roome.domain.event.dto;
+
+import com.roome.domain.event.entity.FirstComeEvent;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FirstComeEventResponse {
+
+  private final Long id;
+  private final String eventName;
+  private final int rewardPoints;
+  private final int maxParticipants;
+  private final LocalDateTime eventTime;
+
+  public static FirstComeEventResponse fromEntity(FirstComeEvent event) {
+    return new FirstComeEventResponse(
+        event.getId(),
+        event.getEventName(),
+        event.getRewardPoints(),
+        event.getMaxParticipants(),
+        event.getEventTime()
+    );
+  }
+}

--- a/roome/src/main/java/com/roome/domain/event/entity/EventStatus.java
+++ b/roome/src/main/java/com/roome/domain/event/entity/EventStatus.java
@@ -1,0 +1,6 @@
+package com.roome.domain.event.entity;
+
+public enum EventStatus {
+  ONGOING,    // 진행 중
+  ENDED       // 종료됨
+}

--- a/roome/src/main/java/com/roome/domain/event/entity/FirstComeEvent.java
+++ b/roome/src/main/java/com/roome/domain/event/entity/FirstComeEvent.java
@@ -3,6 +3,8 @@ package com.roome.domain.event.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,20 +40,29 @@ public class FirstComeEvent {
   @Column(nullable = false)
   private LocalDateTime eventTime; // 이벤트 시작 시간
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private EventStatus status;
+
   @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<EventParticipation> participants = new ArrayList<>();
 
   @Builder
   public FirstComeEvent(String eventName, int rewardPoints, int maxParticipants,
-      LocalDateTime eventTime) {
+      LocalDateTime eventTime, EventStatus status) {
     this.eventName = eventName;
     this.rewardPoints = rewardPoints;
     this.maxParticipants = maxParticipants;
     this.eventTime = eventTime;
+    this.status = status;
   }
 
   public boolean isEventOpen() {
     return LocalDateTime.now().isAfter(eventTime);
+  }
+
+  public void endEvent() {
+    this.status = EventStatus.ENDED;
   }
 }
 

--- a/roome/src/main/java/com/roome/domain/event/repository/FirstComeEventRepository.java
+++ b/roome/src/main/java/com/roome/domain/event/repository/FirstComeEventRepository.java
@@ -1,6 +1,8 @@
 package com.roome.domain.event.repository;
 
+import com.roome.domain.event.entity.EventStatus;
 import com.roome.domain.event.entity.FirstComeEvent;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,6 +10,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FirstComeEventRepository extends JpaRepository<FirstComeEvent, Long> {
 
-  Optional<FirstComeEvent> findTopByOrderByEventTimeDesc(); // 가장 최근 이벤트 조회
+  List<FirstComeEvent> findByStatus(EventStatus status);
+
+  // 진행 중인 가장 최신 이벤트 조회
+  Optional<FirstComeEvent> findTopByStatusOrderByEventTimeDesc(EventStatus status);
+
 }
 

--- a/roome/src/main/java/com/roome/domain/event/service/FirstComeEventScheduler.java
+++ b/roome/src/main/java/com/roome/domain/event/service/FirstComeEventScheduler.java
@@ -1,6 +1,10 @@
 package com.roome.domain.event.service;
 
+import com.roome.domain.event.entity.EventStatus;
+import com.roome.domain.event.entity.FirstComeEvent;
+import com.roome.domain.event.repository.FirstComeEventRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,13 +15,37 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class FirstComeEventScheduler {
 
-  private final FirstComeEventService firstComeEventService;
+  private final FirstComeEventRepository firstComeEventRepository;
 
-  // 매주 수요일 18:00 이벤트 자동 생성
-  @Scheduled(cron = "15 12 21 ? * TUE")
-  public void createWeeklyEvent() {
-    log.info("이벤트 자동 생성");
-    firstComeEventService.createEvent("주간 선착순 이벤트", 200, 1, LocalDateTime.now().plusSeconds(10));
-    log.info("이벤트 생성 완료");
+  // 테스트 환경: 5분마다 이벤트 자동 생성
+  @Scheduled(cron = "0 */5 * * * *")
+  public void createTestEvent() {
+    log.info("🔹 [테스트] 주간 선착순 이벤트 자동 생성 시작");
+
+    FirstComeEvent event = FirstComeEvent.builder()
+        .eventName("테스트 선착순 이벤트")
+        .rewardPoints(200)
+        .maxParticipants(10)
+        .eventTime(LocalDateTime.now()) // 즉시 진행
+        .status(EventStatus.ONGOING) // 바로 진행 중 상태
+        .build();
+
+    firstComeEventRepository.save(event);
+    log.info("✅ [테스트] 이벤트 생성 완료: {}", event.getEventTime());
+  }
+
+  // 테스트 환경: 3분 이상 지난 이벤트 자동 종료
+  @Scheduled(cron = "0 */1 * * * *") // 1분마다 실행
+  public void updateEndedTestEvents() {
+    List<FirstComeEvent> ongoingEvents = firstComeEventRepository.findByStatus(EventStatus.ONGOING);
+    LocalDateTime now = LocalDateTime.now().minusMinutes(3); // 3분 이상 지난 이벤트 종료
+
+    for (FirstComeEvent event : ongoingEvents) {
+      if (event.getEventTime().isBefore(now)) {
+        event.endEvent();
+        firstComeEventRepository.save(event);
+        log.info("🚫 [테스트] 이벤트 종료됨: {}", event.getEventName());
+      }
+    }
   }
 }

--- a/roome/src/main/java/com/roome/domain/event/service/FirstComeEventService.java
+++ b/roome/src/main/java/com/roome/domain/event/service/FirstComeEventService.java
@@ -1,11 +1,9 @@
 package com.roome.domain.event.service;
 
 import com.roome.domain.event.entity.EventParticipation;
+import com.roome.domain.event.entity.EventStatus;
 import com.roome.domain.event.entity.FirstComeEvent;
-import com.roome.domain.event.exception.AlreadyParticipatedException;
-import com.roome.domain.event.exception.EventFullException;
-import com.roome.domain.event.exception.EventNotFoundException;
-import com.roome.domain.event.exception.EventNotStartedException;
+import com.roome.domain.event.exception.*;
 import com.roome.domain.event.repository.EventParticipationRepository;
 import com.roome.domain.event.repository.FirstComeEventRepository;
 import com.roome.domain.point.entity.PointReason;
@@ -13,10 +11,10 @@ import com.roome.domain.point.service.PointService;
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
 import com.roome.global.jwt.exception.UserNotFoundException;
-import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,48 +25,35 @@ public class FirstComeEventService {
   private final UserRepository userRepository;
   private final PointService pointService;
 
-  // 자동 이벤트 생성 (테스트 중에는 일정 조정 가능)
-  @Transactional
-  public void createEvent(String eventName, int rewardPoints, int maxParticipants, LocalDateTime eventTime) {
-    FirstComeEvent event = FirstComeEvent.builder()
-        .eventName(eventName)
-        .rewardPoints(rewardPoints)
-        .maxParticipants(maxParticipants)
-        .eventTime(eventTime)
-        .build();
-    firstComeEventRepository.save(event);
-  }
-
-  // 선착순 이벤트 참여
   @Transactional
   public void joinEvent(Long userId, Long eventId) {
     FirstComeEvent event = firstComeEventRepository.findById(eventId)
         .orElseThrow(EventNotFoundException::new);
 
-    // 이벤트가 시작되었는지 확인
     if (!event.isEventOpen()) {
       throw new EventNotStartedException();
     }
 
-    // 사용자 조회
     User user = userRepository.findById(userId)
         .orElseThrow(UserNotFoundException::new);
 
-    // 이미 참여했는지 확인
     if (eventParticipationRepository.existsByUserIdAndEventId(user.getId(), eventId)) {
       throw new AlreadyParticipatedException();
     }
 
-    // 현재 참여 인원 체크
     long participantCount = eventParticipationRepository.countByEventId(eventId);
     if (participantCount >= event.getMaxParticipants()) {
       throw new EventFullException();
     }
 
-    // 이벤트 참여 기록 저장
     eventParticipationRepository.save(new EventParticipation(user, event, LocalDateTime.now()));
 
-    // 포인트 지급
     pointService.earnPoints(user, PointReason.FIRST_COME_EVENT);
+  }
+
+  @Transactional(readOnly = true)
+  public FirstComeEvent getOngoingEvent() {
+    return firstComeEventRepository.findTopByStatusOrderByEventTimeDesc(EventStatus.ONGOING)
+        .orElseThrow(EventNotFoundException::new);
   }
 }


### PR DESCRIPTION
## 📌 PR 제목 Feat: 선착순 이벤트 상태 관리 방식 개선 및 조회 기능 추가 

### ✅ PR 설명
선착순 이벤트를 자동 생성하고, 사용자가 참여할 수 있도록 기능을 구현했습니다.

### 🏗 작업 내용
- [ ] TODO 1 (어떤 기능을 개발했는지)
- [ ] TODO 2 (관련 API가 있다면 명시)
- [ ] TODO 3 (테스트 여부 등)

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
