### PR TITLE
Test: CdCommentController & CdCommentService 테스트 커버리지 개선

### DIFF
--- a/roome/src/test/java/com/roome/domain/cdcomment/controller/CdCommentControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/cdcomment/controller/CdCommentControllerTest.java
@@ -1,156 +1,137 @@
-//package com.roome.domain.cdcomment.controller;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.roome.domain.cdcomment.dto.CdCommentCreateRequest;
-//import com.roome.domain.cdcomment.dto.CdCommentListResponse;
-//import com.roome.domain.cdcomment.dto.CdCommentResponse;
-//import com.roome.domain.cdcomment.service.CdCommentService;
-//import com.roome.global.exception.ForbiddenException;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.BDDMockito;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.http.MediaType;
-//import org.springframework.security.test.context.support.WithMockUser;
-//import org.springframework.test.web.servlet.MockMvc;
-//
-//import java.time.LocalDateTime;
-//import java.util.List;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-//
-//@WebMvcTest(CdCommentController.class)
-//@AutoConfigureMockMvc
-//class CdCommentControllerTest {
-//
-//  @Autowired
-//  private MockMvc mockMvc;
-//
-//  @MockBean
-//  private CdCommentService cdCommentService;
-//
-//  @Autowired
-//  private ObjectMapper objectMapper;
-//
-//  @DisplayName("댓글 추가 성공")
-//  @WithMockUser(username = "1")
-//  @Test
-//  void addComment_Success() throws Exception {
-//    CdCommentCreateRequest request = createCdCommentCreateRequest();
-//    CdCommentResponse response = createCdCommentResponse(1L, request);
-//
-//    BDDMockito.given(
-//            cdCommentService.addComment(eq(1L), any(Long.class), any(CdCommentCreateRequest.class)))
-//        .willReturn(response);
-//
-//    mockMvc.perform(post("/api/my-cd/1/comment")
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .content(objectMapper.writeValueAsString(request))
-//            .with(csrf()))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.content").value("이 곡 최고네요!"))
-//        .andExpect(jsonPath("$.timestamp").value(220));
-//  }
-//
-//  @DisplayName("CD의 댓글 목록 조회 성공")
-//  @WithMockUser
-//  @Test
-//  void getComments_Success() throws Exception {
-//    CdCommentListResponse response = new CdCommentListResponse(
-//        List.of(createCdCommentResponse(1L, createCdCommentCreateRequest())), 0, 5, 1, 1
-//    );
-//
-//    BDDMockito.given(cdCommentService.getComments(eq(1L), any(Integer.class), any(Integer.class)))
-//        .willReturn(response);
-//
-//    mockMvc.perform(get("/api/my-cd/1/comments")
-//            .param("page", "0")
-//            .param("size", "5")
-//            .accept(MediaType.APPLICATION_JSON))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.data[0].content").value("이 곡 최고네요!"));
-//  }
-//
-//  @DisplayName("CD 전체 댓글 목록 조회 성공")
-//  @WithMockUser
-//  @Test
-//  void getAllComments_Success() throws Exception {
-//    List<CdCommentResponse> response = List.of(
-//        createCdCommentResponse(1L, createCdCommentCreateRequest()),
-//        createCdCommentResponse(2L, new CdCommentCreateRequest(260, "이 곡도 좋아요!"))
-//    );
-//
-//    BDDMockito.given(cdCommentService.getAllComments(eq(1L)))
-//        .willReturn(response);
-//
-//    mockMvc.perform(get("/api/my-cd/1/comments/all")
-//            .accept(MediaType.APPLICATION_JSON))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.length()").value(2))
-//        .andExpect(jsonPath("$[0].content").value("이 곡 최고네요!"))
-//        .andExpect(jsonPath("$[1].content").value("이 곡도 좋아요!"));
-//  }
-//
-//  @DisplayName("CD 댓글 검색 성공")
-//  @WithMockUser
-//  @Test
-//  void searchComments_Success() throws Exception {
-//    CdCommentListResponse response = new CdCommentListResponse(
-//        List.of(createCdCommentResponse(1L, createCdCommentCreateRequest())), 0, 5, 1, 1
-//    );
-//
-//    BDDMockito.given(
-//            cdCommentService.searchComments(eq(1L), eq("최고"), any(Integer.class), any(Integer.class)))
-//        .willReturn(response);
-//
-//    mockMvc.perform(get("/api/my-cd/1/comments/search")
-//            .param("query", "최고")
-//            .param("page", "0")
-//            .param("size", "5")
-//            .accept(MediaType.APPLICATION_JSON))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.data[0].content").value("이 곡 최고네요!"));
-//  }
-//
-//  @DisplayName("CD 댓글 삭제 성공 (작성자 또는 방 주인)")
-//  @WithMockUser(username = "1")
-//  @Test
-//  void deleteComment_Success() throws Exception {
-//    mockMvc.perform(delete("/api/my-cd/comments/1")
-//            .with(csrf()))
-//        .andExpect(status().isNoContent());
-//
-//    BDDMockito.verify(cdCommentService).deleteComment(eq(1L), eq(1L));
-//  }
-//
-//  @DisplayName("CD 댓글 삭제 실패 (권한 없음)")
-//  @WithMockUser(username = "3", roles = "USER")
-//  @Test
-//  void deleteComment_Unauthorized() throws Exception {
-//    BDDMockito.doThrow(new ForbiddenException("해당 댓글을 삭제할 권한이 없습니다."))
-//        .when(cdCommentService).deleteComment(eq(3L), eq(1L));
-//
-//    mockMvc.perform(delete("/api/my-cd/comments/1")
-//            .with(csrf()))
-//        .andExpect(status().isForbidden());
-//  }
-//
-//  private CdCommentCreateRequest createCdCommentCreateRequest() {
-//    return new CdCommentCreateRequest(220, "이 곡 최고네요!");
-//  }
-//
-//  private CdCommentResponse createCdCommentResponse(Long commentId,
-//      CdCommentCreateRequest request) {
-//    return new CdCommentResponse(
-//        commentId, 1L, 2L, "현구", request.getTimestamp(),
-//        request.getContent(), LocalDateTime.now()
-//    );
-//  }
-//}
+package com.roome.domain.cdcomment.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roome.domain.cdcomment.dto.CdCommentCreateRequest;
+import com.roome.domain.cdcomment.dto.CdCommentListResponse;
+import com.roome.domain.cdcomment.dto.CdCommentResponse;
+import com.roome.domain.cdcomment.service.CdCommentService;
+import com.roome.global.exception.ForbiddenException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CdCommentController.class)
+@AutoConfigureMockMvc
+class CdCommentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private CdCommentService cdCommentService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @DisplayName("CD 댓글 추가 성공")
+  @WithMockUser(username = "1")
+  @Test
+  void addComment_Success() throws Exception {
+    CdCommentCreateRequest request = new CdCommentCreateRequest(220, "이 곡 최고네요!");
+    CdCommentResponse response = createCdCommentResponse(1L, request);
+
+    BDDMockito.given(cdCommentService.addComment(eq(1L), eq(1L), any(CdCommentCreateRequest.class)))
+        .willReturn(response);
+
+    mockMvc.perform(post("/api/my-cd/1/comments")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value("이 곡 최고네요!"))
+        .andExpect(jsonPath("$.timestamp").value(220));
+  }
+
+  @DisplayName("CD 댓글 목록 조회 성공")
+  @WithMockUser
+  @Test
+  void getComments_Success() throws Exception {
+    CdCommentListResponse response = new CdCommentListResponse(
+        List.of(createCdCommentResponse(1L, new CdCommentCreateRequest(220, "이 곡 최고네요!"))),
+        0, 5, 1, 1
+    );
+
+    BDDMockito.given(cdCommentService.getComments(eq(1L), any(), anyInt(), anyInt()))
+        .willReturn(response);
+
+    System.out.println("Mock Response: " + objectMapper.writeValueAsString(response));
+
+    mockMvc.perform(get("/api/my-cd/1/comments")
+            .param("page", "0")
+            .param("size", "5")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].content").value("이 곡 최고네요!"));
+  }
+
+  @DisplayName("CD 전체 댓글 목록 조회 성공")
+  @WithMockUser
+  @Test
+  void getAllComments_Success() throws Exception {
+    List<CdCommentResponse> response = List.of(
+        createCdCommentResponse(1L, new CdCommentCreateRequest(220, "이 곡 최고네요!")),
+        createCdCommentResponse(2L, new CdCommentCreateRequest(250, "이 곡도 좋네요!"))
+    );
+
+    BDDMockito.given(cdCommentService.getAllComments(eq(1L)))
+        .willReturn(response);
+
+    System.out.println("Mock Response: " + objectMapper.writeValueAsString(response));
+
+    mockMvc.perform(get("/api/my-cd/1/comments/all")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].content").value("이 곡 최고네요!"))
+        .andExpect(jsonPath("$[1].content").value("이 곡도 좋네요!"));
+  }
+
+
+  @DisplayName("CD 댓글 삭제 성공")
+  @WithMockUser(username = "1")
+  @Test
+  void deleteComment_Success() throws Exception {
+    mockMvc.perform(delete("/api/my-cd/1/comments/1")
+            .with(csrf()))
+        .andExpect(status().isNoContent());
+
+    BDDMockito.verify(cdCommentService).deleteComment(eq(1L), eq(1L));
+  }
+
+  @DisplayName("CD 댓글 삭제 실패 (권한 없음)")
+  @WithMockUser(username = "3")
+  @Test
+  void deleteComment_Unauthorized() throws Exception {
+    BDDMockito.doThrow(new ForbiddenException("해당 댓글을 삭제할 권한이 없습니다."))
+        .when(cdCommentService).deleteComment(eq(3L), eq(1L));
+
+    mockMvc.perform(delete("/api/my-cd/1/comments/1")
+            .with(csrf()))
+        .andExpect(status().isForbidden());
+  }
+
+  private CdCommentResponse createCdCommentResponse(Long commentId,
+      CdCommentCreateRequest request) {
+    return new CdCommentResponse(
+        commentId, 1L, 2L, "현구", request.getTimestamp(),
+        request.getContent(), LocalDateTime.of(2024, 3, 5, 12, 0, 0)
+    );
+  }
+}

--- a/roome/src/test/java/com/roome/domain/cdcomment/service/CdCommentServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/cdcomment/service/CdCommentServiceTest.java
@@ -1,183 +1,179 @@
-//package com.roome.domain.cdcomment.service;
-//
-//import com.roome.domain.cdcomment.dto.CdCommentCreateRequest;
-//import com.roome.domain.cdcomment.dto.CdCommentListResponse;
-//import com.roome.domain.cdcomment.dto.CdCommentResponse;
-//import com.roome.domain.cdcomment.entity.CdComment;
-//import com.roome.domain.cdcomment.exception.CdCommentListEmptyException;
-//import com.roome.domain.cdcomment.exception.CdCommentNotFoundException;
-//import com.roome.domain.cdcomment.exception.CdCommentSearchEmptyException;
-//import com.roome.domain.cdcomment.repository.CdCommentRepository;
-//import com.roome.domain.mycd.entity.MyCd;
-//import com.roome.domain.mycd.exception.MyCdNotFoundException;
-//import com.roome.domain.mycd.repository.MyCdRepository;
-//import com.roome.domain.user.entity.User;
-//import com.roome.domain.user.repository.UserRepository;
-//import com.roome.global.exception.ForbiddenException;
-//import com.roome.global.jwt.exception.UserNotFoundException;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.domain.*;
-//
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class CdCommentServiceTest {
-//
-//  @Mock private CdCommentRepository cdCommentRepository;
-//  @Mock private MyCdRepository myCdRepository;
-//  @Mock private UserRepository userRepository;
-//
-//  @InjectMocks private CdCommentService cdCommentService;
-//
-//  private User user;
-//  private User roomOwner;
-//  private MyCd myCd;
-//  private CdComment cdComment;
-//
-//  @BeforeEach
-//  void setUp() {
-//    user = User.builder().id(1L).nickname("현구").build();
-//    roomOwner = User.builder().id(2L).nickname("방 주인").build();
-//    myCd = MyCd.builder().id(1L).user(roomOwner).build();
-//    cdComment = CdComment.builder().id(1L).user(user).myCd(myCd).timestamp(220).content("이 곡 최고네요!").build();
-//  }
-//
-//  @Test
-//  @DisplayName("댓글 추가 성공")
-//  void addComment_Success() {
-//    CdCommentCreateRequest request = new CdCommentCreateRequest(220, "이 곡 최고네요!");
-//
-//    when(myCdRepository.findById(1L)).thenReturn(Optional.of(myCd));
-//    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-//    when(cdCommentRepository.save(any(CdComment.class))).thenReturn(cdComment);
-//
-//    CdCommentResponse response = cdCommentService.addComment(1L, 1L, request);
-//
-//    assertThat(response.getContent()).isEqualTo(request.getContent());
-//    assertThat(response.getTimestamp()).isEqualTo(request.getTimestamp());
-//  }
-//
-//  @Test
-//  @DisplayName("CD 전체 댓글 목록 조회 성공")
-//  void getAllComments_Success() {
-//    List<CdComment> comments = List.of(cdComment);
-//
-//    when(cdCommentRepository.findByMyCdId(1L)).thenReturn(comments);
-//
-//    List<CdCommentResponse> response = cdCommentService.getAllComments(1L);
-//
-//    assertThat(response).hasSize(1);
-//    assertThat(response.get(0).getContent()).isEqualTo("이 곡 최고네요!");
-//  }
-//
-//  @Test
-//  @DisplayName("CD 전체 댓글 목록이 비어있을 때 예외 발생")
-//  void getAllComments_EmptyList() {
-//    when(cdCommentRepository.findByMyCdId(1L)).thenReturn(List.of());
-//
-//    assertThatThrownBy(() -> cdCommentService.getAllComments(1L))
-//        .isInstanceOf(CdCommentListEmptyException.class);
-//  }
-//
-//  @Test
-//  @DisplayName("댓글 목록 조회 성공")
-//  void getComments_Success() {
-//    PageRequest pageRequest = PageRequest.of(0, 5);
-//    Page<CdComment> commentPage = new PageImpl<>(List.of(cdComment), pageRequest, 1);
-//
-//    when(cdCommentRepository.findByMyCdId(1L, pageRequest)).thenReturn(commentPage);
-//
-//    CdCommentListResponse response = cdCommentService.getComments(1L, 0, 5);
-//
-//    assertThat(response.getData()).hasSize(1);
-//    assertThat(response.getData().get(0).getContent()).isEqualTo("이 곡 최고네요!");
-//  }
-//
-//  @Test
-//  @DisplayName("댓글 목록 조회 실패 (댓글 없음)")
-//  void getComments_EmptyList() {
-//    PageRequest pageRequest = PageRequest.of(0, 5);
-//    Page<CdComment> emptyPage = Page.empty(pageRequest);
-//
-//    when(cdCommentRepository.findByMyCdId(1L, pageRequest)).thenReturn(emptyPage);
-//
-//    assertThatThrownBy(() -> cdCommentService.getComments(1L, 0, 5))
-//        .isInstanceOf(CdCommentListEmptyException.class);
-//  }
-//
-//  @Test
-//  @DisplayName("댓글 검색 성공")
-//  void searchComments_Success() {
-//    Pageable pageable = PageRequest.of(0, 5);
-//    Page<CdComment> commentPage = new PageImpl<>(List.of(cdComment), pageable, 1);
-//
-//    when(cdCommentRepository.findByMyCdIdAndKeyword(1L, "최고", pageable)).thenReturn(commentPage);
-//
-//    CdCommentListResponse response = cdCommentService.searchComments(1L, "최고", 0, 5);
-//
-//    assertThat(response.getData()).hasSize(1);
-//    assertThat(response.getData().get(0).getContent()).isEqualTo("이 곡 최고네요!");
-//  }
-//
-//  @Test
-//  @DisplayName("댓글 검색 실패 (검색 결과 없음)")
-//  void searchComments_EmptyResult() {
-//    Pageable pageable = PageRequest.of(0, 5);
-//    Page<CdComment> emptyPage = Page.empty(pageable);
-//
-//    when(cdCommentRepository.findByMyCdIdAndKeyword(1L, "없는키워드", pageable)).thenReturn(emptyPage);
-//
-//    assertThatThrownBy(() -> cdCommentService.searchComments(1L, "없는키워드", 0, 5))
-//        .isInstanceOf(CdCommentSearchEmptyException.class);
-//  }
-//
-//  @Test
-//  @DisplayName("댓글 삭제 성공 (댓글 작성자)")
-//  void deleteComment_Success_ByAuthor() {
-//    when(cdCommentRepository.findById(1L)).thenReturn(Optional.of(cdComment));
-//
-//    cdCommentService.deleteComment(1L, 1L);
-//
-//    verify(cdCommentRepository, times(1)).delete(cdComment);
-//  }
-//
-//  @Test
-//  @DisplayName("댓글 삭제 성공 (방 주인)")
-//  void deleteComment_Success_ByRoomOwner() {
-//    when(cdCommentRepository.findById(1L)).thenReturn(Optional.of(cdComment));
-//
-//    cdCommentService.deleteComment(2L, 1L);
-//
-//    verify(cdCommentRepository, times(1)).delete(cdComment);
-//  }
-//
-//  @Test
-//  @DisplayName("댓글 삭제 실패 (권한 없음)")
-//  void deleteComment_Unauthorized() {
-//    User anotherUser = User.builder().id(3L).nickname("다른 사용자").build();
-//    when(cdCommentRepository.findById(1L)).thenReturn(Optional.of(cdComment));
-//
-//    assertThatThrownBy(() -> cdCommentService.deleteComment(3L, 1L))
-//        .isInstanceOf(ForbiddenException.class);
-//  }
-//
-//  @Test
-//  @DisplayName("존재하지 않는 댓글 삭제 시 예외 발생")
-//  void deleteComment_NotFound() {
-//    when(cdCommentRepository.findById(1L)).thenReturn(Optional.empty());
-//
-//    assertThatThrownBy(() -> cdCommentService.deleteComment(1L, 1L))
-//        .isInstanceOf(CdCommentNotFoundException.class);
-//  }
-//}
+package com.roome.domain.cdcomment.service;
+
+import com.roome.domain.cdcomment.dto.CdCommentCreateRequest;
+import com.roome.domain.cdcomment.dto.CdCommentListResponse;
+import com.roome.domain.cdcomment.dto.CdCommentResponse;
+import com.roome.domain.cdcomment.entity.CdComment;
+import com.roome.domain.cdcomment.exception.CdCommentListEmptyException;
+import com.roome.domain.cdcomment.exception.CdCommentNotFoundException;
+import com.roome.domain.cdcomment.repository.CdCommentRepository;
+import com.roome.domain.mycd.entity.MyCd;
+import com.roome.domain.mycd.repository.MyCdRepository;
+import com.roome.domain.rank.service.UserActivityService;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import com.roome.global.exception.ForbiddenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class CdCommentServiceTest {
+
+  @Mock private CdCommentRepository cdCommentRepository;
+  @Mock private MyCdRepository myCdRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private UserActivityService userActivityService;
+
+  @InjectMocks private CdCommentService cdCommentService;
+
+  private User user;
+  private User roomOwner;
+  private MyCd myCd;
+  private CdComment cdComment;
+
+  @BeforeEach
+  void setUp() {
+    user = User.builder().id(1L).nickname("현구").build();
+    roomOwner = User.builder().id(2L).nickname("방 주인").build();
+    myCd = MyCd.builder().id(1L).user(roomOwner).build();
+    cdComment = CdComment.builder().id(1L).user(user).myCd(myCd).timestamp(220).content("이 곡 최고네요!").build();
+  }
+
+  @Test
+  @DisplayName("댓글 추가 성공")
+  void addComment_Success() {
+    CdCommentCreateRequest request = new CdCommentCreateRequest(220, "이 곡 최고네요!");
+
+    when(myCdRepository.findById(1L)).thenReturn(Optional.of(myCd));
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+    when(cdCommentRepository.save(any(CdComment.class))).thenReturn(cdComment);
+
+    // 이벤트 발행을 Mock 처리
+    doNothing().when(eventPublisher).publishEvent(any());
+
+    // 활동 기록을 Mock 처리 (doAnswer 사용)
+    doAnswer(invocation -> null).when(userActivityService).recordUserActivity(anyLong(), any(), anyLong());
+
+    CdCommentResponse response = cdCommentService.addComment(1L, 1L, request);
+
+    assertThat(response.getContent()).isEqualTo(request.getContent());
+    assertThat(response.getTimestamp()).isEqualTo(request.getTimestamp());
+  }
+
+  @Test
+  @DisplayName("CD 전체 댓글 목록 조회 성공")
+  void getAllComments_Success() {
+    List<CdComment> comments = List.of(cdComment);
+
+    when(cdCommentRepository.findByMyCdId(1L)).thenReturn(comments);
+
+    List<CdCommentResponse> response = cdCommentService.getAllComments(1L);
+
+    assertThat(response).hasSize(1);
+    assertThat(response.get(0).getContent()).isEqualTo("이 곡 최고네요!");
+  }
+
+  @Test
+  @DisplayName("CD 전체 댓글 목록이 비어있을 때 예외 발생")
+  void getAllComments_EmptyList() {
+    when(cdCommentRepository.findByMyCdId(1L)).thenReturn(List.of());
+
+    assertThatThrownBy(() -> cdCommentService.getAllComments(1L))
+        .isInstanceOf(CdCommentListEmptyException.class);
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 성공 - 키워드 없음")
+  void getComments_Success_NoKeyword() {
+    PageRequest pageRequest = PageRequest.of(0, 5);
+    Page<CdComment> commentPage = new PageImpl<>(List.of(cdComment), pageRequest, 1);
+
+    when(cdCommentRepository.findByMyCdId(1L, pageRequest)).thenReturn(commentPage);
+
+    CdCommentListResponse response = cdCommentService.getComments(1L, null, 0, 5);
+
+    assertThat(response.getData()).hasSize(1);
+    assertThat(response.getData().get(0).getContent()).isEqualTo("이 곡 최고네요!");
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 성공 - 키워드 있음")
+  void getComments_Success_WithKeyword() {
+    PageRequest pageRequest = PageRequest.of(0, 5);
+    Page<CdComment> commentPage = new PageImpl<>(List.of(cdComment), pageRequest, 1);
+
+    when(cdCommentRepository.findByMyCdIdAndKeyword(1L, "테스트", pageRequest)).thenReturn(commentPage);
+
+    CdCommentListResponse response = cdCommentService.getComments(1L, "테스트", 0, 5);
+
+    assertThat(response.getData()).hasSize(1);
+    assertThat(response.getData().get(0).getContent()).isEqualTo("이 곡 최고네요!");
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회 실패 (댓글 없음)")
+  void getComments_EmptyList() {
+    PageRequest pageRequest = PageRequest.of(0, 5);
+    Page<CdComment> emptyPage = Page.empty(pageRequest);
+
+    when(cdCommentRepository.findByMyCdId(1L, pageRequest)).thenReturn(emptyPage);
+
+    assertThatThrownBy(() -> cdCommentService.getComments(1L, null, 0, 5))
+        .isInstanceOf(CdCommentListEmptyException.class);
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 성공 (댓글 작성자)")
+  void deleteComment_Success_ByAuthor() {
+    when(cdCommentRepository.findById(1L)).thenReturn(Optional.of(cdComment));
+
+    cdCommentService.deleteComment(1L, 1L);
+
+    verify(cdCommentRepository, times(1)).delete(cdComment);
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 성공 (방 주인)")
+  void deleteComment_Success_ByRoomOwner() {
+    when(cdCommentRepository.findById(1L)).thenReturn(Optional.of(cdComment));
+
+    cdCommentService.deleteComment(2L, 1L);
+
+    verify(cdCommentRepository, times(1)).delete(cdComment);
+  }
+
+  @Test
+  @DisplayName("댓글 삭제 실패 (권한 없음)")
+  void deleteComment_Unauthorized() {
+    User anotherUser = User.builder().id(3L).nickname("다른 사용자").build();
+    when(cdCommentRepository.findById(1L)).thenReturn(Optional.of(cdComment));
+
+    assertThatThrownBy(() -> cdCommentService.deleteComment(3L, 1L))
+        .isInstanceOf(ForbiddenException.class);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 댓글 삭제 시 예외 발생")
+  void deleteComment_NotFound() {
+    when(cdCommentRepository.findById(1L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> cdCommentService.deleteComment(1L, 1L))
+        .isInstanceOf(CdCommentNotFoundException.class);
+  }
+}


### PR DESCRIPTION
## 📌 PR 제목 Test: CdCommentController & CdCommentService 테스트 커버리지 개선

### ✅ PR 설명
CdComment 테스트 코드 개선했습니다.

### 🏗 작업 내용
- CdCommentControllerTest 추가 및 테스트 커버리지 100% 달성
- CdCommentServiceTest에서 모든 주요 메서드 테스트, 커버리지 92% 달성
- 댓글 조회(getComments)에서 키워드 여부에 따른 테스트 추가
- PageRequest 음수 인덱스 방지 처리 추가
- 이벤트 발행(`ApplicationEventPublisher`) 및 사용자 활동 기록(`UserActivityService`) Mock 처리하여 안정성 개선

### 📸 테스트 결과 (선택)
> 
![image](https://github.com/user-attachments/assets/f74ab487-a450-46fb-b994-a220f24ab520)
![image](https://github.com/user-attachments/assets/5a4f71b9-c528-4a15-be89-bab4898f3831)


### 🔗 관련 이슈 (선택)
> #292 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
