### PR TITLE
Fix: 하우스메이트 추가 시 랭킹 점수 부여 로직 개선

### DIFF
--- a/roome/src/main/java/com/roome/domain/houseMate/service/HousemateService.java
+++ b/roome/src/main/java/com/roome/domain/houseMate/service/HousemateService.java
@@ -65,12 +65,12 @@ public class HousemateService {
         AddedHousemate.builder().userId(userId).addedId(targetId).build());
 
     //팔로워 증가 활동 기록 (팔로잉 받은 사람에게 점수 부여)
-//    try {
-//      userActivityService.recordFollowActivity(userId, targetId);
-//    } catch (Exception e) {
-//      log.error("팔로워 활동 기록 중 오류 발생: {}", e.getMessage(), e);
-//      // 활동 기록 실패가 기존 비즈니스 로직에 영향을 주지 않도록 예외를 잡아서 처리
-//    }
+    try {
+      userActivityService.recordFollowActivity(userId, targetId);
+    } catch (Exception e) {
+      log.error("팔로워 활동 기록 중 오류 발생: {}", e.getMessage(), e);
+      // 활동 기록 실패가 기존 비즈니스 로직에 영향을 주지 않도록 예외를 잡아서 처리
+    }
 
     // 하우스메이트 추가 알림 발행
     log.info("하우스메이트 알림 이벤트 발행: 발신자={}, 수신자={}, 대상 ID={}", userId, targetId, targetId);

--- a/roome/src/test/java/com/roome/domain/rank/service/RankingSchedulerTest.java
+++ b/roome/src/test/java/com/roome/domain/rank/service/RankingSchedulerTest.java
@@ -1,119 +1,124 @@
-//package com.roome.domain.rank.service;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//import com.roome.domain.point.entity.Point;
-//import com.roome.domain.point.entity.PointHistory;
-//import com.roome.domain.point.repository.PointHistoryRepository;
-//import com.roome.domain.point.repository.PointRepository;
-//import com.roome.domain.rank.repository.UserActivityRepository;
-//import com.roome.domain.user.entity.User;
-//import com.roome.domain.user.repository.UserRepository;
-//import java.time.LocalDateTime;
-//import java.util.LinkedHashSet;
-//import java.util.Optional;
-//import java.util.Set;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.Mockito;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.redis.core.RedisTemplate;
-//import org.springframework.data.redis.core.ZSetOperations;
-//
-//@ExtendWith(MockitoExtension.class)
-//public class RankingSchedulerTest {
-//
-//  @Mock
-//  private RedisTemplate<String, Object> redisTemplate;
-//
-//  @Mock
-//  private ZSetOperations<String, Object> zSetOperations;
-//
-//  @Mock
-//  private UserActivityRepository userActivityRepository;
-//
-//  @Mock
-//  private UserRepository userRepository;
-//
-//  @Mock
-//  private PointRepository pointRepository;
-//
-//  @Mock
-//  private PointHistoryRepository pointHistoryRepository;
-//
-//  @InjectMocks
-//  private RankingScheduler rankingScheduler;
-//
-//  @BeforeEach
-//  void setUp() {
-//    when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
-//  }
-//
-//  @DisplayName("주간 랭킹 보상 지급 테스트")
-//  @Test
-//  void awardWeeklyPointsTest() {
-//    // Given
-//    Set<ZSetOperations.TypedTuple<Object>> topRankers = new LinkedHashSet<>();
-//
-//    // 1등 모킹
-//    ZSetOperations.TypedTuple<Object> firstRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
-//    when(firstRanker.getValue()).thenReturn("1");
-//    when(firstRanker.getScore()).thenReturn(100.0);
-//    topRankers.add(firstRanker);
-//
-//    // 2등 모킹
-//    ZSetOperations.TypedTuple<Object> secondRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
-//    when(secondRanker.getValue()).thenReturn("2");
-//    when(secondRanker.getScore()).thenReturn(80.0);
-//    topRankers.add(secondRanker);
-//
-//    // 3등 모킹
-//    ZSetOperations.TypedTuple<Object> thirdRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
-//    when(thirdRanker.getValue()).thenReturn("3");
-//    when(thirdRanker.getScore()).thenReturn(70.0);
-//    topRankers.add(thirdRanker);
-//
-//    when(zSetOperations.reverseRangeWithScores("user:ranking", 0, 2)).thenReturn(topRankers);
-//
-//    // 유저 정보 모킹
-//    User user1 = Mockito.mock(User.class);
-//    User user2 = Mockito.mock(User.class);
-//    User user3 = Mockito.mock(User.class);
-//
-//    when(userRepository.findById(1L)).thenReturn(Optional.of(user1));
-//    when(userRepository.findById(2L)).thenReturn(Optional.of(user2));
-//    when(userRepository.findById(3L)).thenReturn(Optional.of(user3));
-//
-//    // 포인트 정보 모킹
-//    Point point1 = Mockito.mock(Point.class);
-//    Point point2 = Mockito.mock(Point.class);
-//    Point point3 = Mockito.mock(Point.class);
-//
-//    when(pointRepository.findByUser(user1)).thenReturn(Optional.of(point1));
-//    when(pointRepository.findByUser(user2)).thenReturn(Optional.of(point2));
-//    when(pointRepository.findByUser(user3)).thenReturn(Optional.of(point3));
-//
-//    // When
-//    rankingScheduler.awardWeeklyPoints();
-//
-//    // Then
-//    verify(point1).addPoints(100);
-//    verify(point2).addPoints(70);
-//    verify(point3).addPoints(50);
-//
-//    verify(pointRepository, times(3)).save(any(Point.class));
-//    verify(pointHistoryRepository, times(3)).save(any(PointHistory.class));
-//
-//    verify(userActivityRepository).deleteAllByCreatedAtBefore(any(LocalDateTime.class));
-//
-//    // redisTemplate.delete는 총 2번 호출됨 (awardWeeklyPoints와 updateRanking에서 각각)
-//    verify(redisTemplate, times(2)).delete("user:ranking");
-//  }
-//}
+package com.roome.domain.rank.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.roome.domain.point.entity.Point;
+import com.roome.domain.point.entity.PointHistory;
+import com.roome.domain.point.repository.PointHistoryRepository;
+import com.roome.domain.point.repository.PointRepository;
+import com.roome.domain.rank.repository.UserActivityRepository;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+@ExtendWith(MockitoExtension.class)
+public class RankingSchedulerTest {
+
+  @Mock
+  private RedisTemplate<String, Object> redisTemplate;
+
+  @Mock
+  private ZSetOperations<String, Object> zSetOperations;
+
+  @Mock
+  private UserActivityRepository userActivityRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private PointRepository pointRepository;
+
+  @Mock
+  private PointHistoryRepository pointHistoryRepository;
+
+  @InjectMocks
+  private RankingScheduler rankingScheduler;
+
+  @BeforeEach
+  void setUp() {
+    when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+  }
+
+  @DisplayName("주간 랭킹 보상 지급 테스트")
+  @Test
+  void awardWeeklyPointsTest() {
+    // Given
+    Set<ZSetOperations.TypedTuple<Object>> topRankers = new LinkedHashSet<>();
+
+    // 1등 모킹
+    ZSetOperations.TypedTuple<Object> firstRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
+    when(firstRanker.getValue()).thenReturn("1");
+    when(firstRanker.getScore()).thenReturn(100.0);
+    topRankers.add(firstRanker);
+
+    // 2등 모킹
+    ZSetOperations.TypedTuple<Object> secondRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
+    when(secondRanker.getValue()).thenReturn("2");
+    when(secondRanker.getScore()).thenReturn(80.0);
+    topRankers.add(secondRanker);
+
+    // 3등 모킹
+    ZSetOperations.TypedTuple<Object> thirdRanker = Mockito.mock(ZSetOperations.TypedTuple.class);
+    when(thirdRanker.getValue()).thenReturn("3");
+    when(thirdRanker.getScore()).thenReturn(70.0);
+    topRankers.add(thirdRanker);
+
+    when(zSetOperations.reverseRangeWithScores("user:ranking", 0, 2)).thenReturn(topRankers);
+
+    // 유저 정보 모킹 - ID 명시적 설정
+    User user1 = Mockito.mock(User.class);
+    when(user1.getId()).thenReturn(1L);
+
+    User user2 = Mockito.mock(User.class);
+    when(user2.getId()).thenReturn(2L);
+
+    User user3 = Mockito.mock(User.class);
+    when(user3.getId()).thenReturn(3L);
+
+    when(userRepository.findById(1L)).thenReturn(Optional.of(user1));
+    when(userRepository.findById(2L)).thenReturn(Optional.of(user2));
+    when(userRepository.findById(3L)).thenReturn(Optional.of(user3));
+
+    // 포인트 정보 모킹
+    Point point1 = Mockito.mock(Point.class);
+    Point point2 = Mockito.mock(Point.class);
+    Point point3 = Mockito.mock(Point.class);
+
+    when(pointRepository.findByUserId(1L)).thenReturn(Optional.of(point1));
+    when(pointRepository.findByUserId(2L)).thenReturn(Optional.of(point2));
+    when(pointRepository.findByUserId(3L)).thenReturn(Optional.of(point3));
+
+    // When
+    rankingScheduler.awardWeeklyPoints();
+
+    // Then
+    verify(point1).addPoints(100);
+    verify(point2).addPoints(70);
+    verify(point3).addPoints(50);
+
+    verify(pointRepository, times(3)).save(any(Point.class));
+    verify(pointHistoryRepository, times(3)).save(any(PointHistory.class));
+
+    verify(userActivityRepository).deleteAllByCreatedAtBefore(any(LocalDateTime.class));
+
+    // redisTemplate.delete는 총 2번 호출됨 (awardWeeklyPoints와 updateRanking에서 각각)
+    verify(redisTemplate, times(2)).delete("user:ranking");
+  }
+}

--- a/roome/src/test/java/com/roome/global/jwt/controller/ReissueControllerTest.java
+++ b/roome/src/test/java/com/roome/global/jwt/controller/ReissueControllerTest.java
@@ -125,7 +125,7 @@ class ReissueControllerTest {
     mockMvc.perform(post("/api/auth/reissue-token").contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)).with(csrf()))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value("리프레시 토큰이 필요합니다."));
+        .andExpect(jsonPath("$.message").value("Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."));
   }
 
   @Test
@@ -139,7 +139,7 @@ class ReissueControllerTest {
     mockMvc.perform(post("/api/auth/reissue-token").contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)).with(csrf()))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value("리프레시 토큰이 필요합니다."));
+        .andExpect(jsonPath("$.message").value("Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."));
   }
 
   @Test
@@ -158,6 +158,6 @@ class ReissueControllerTest {
     mockMvc.perform(post("/api/auth/reissue-token").contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)).with(csrf()))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value("유효하지 않은 리프레시 토큰입니다."));
+        .andExpect(jsonPath("$.message").value("Refresh 토큰이 유효하지 않거나, 입력값이 비어 있습니다."));
   }
 }


### PR DESCRIPTION
## 📌 Fix: 하우스메이트 추가 시 랭킹 점수 부여 로직 개선

### ✅ PR 설명
팔로우 활동 기록 시 발생하는 예외가 핵심 비즈니스 로직에 영향을 주지 않도록 try-catch문으로 예외 처리 강화

### 🏗 작업 내용
- [ ] TODO 1 (어떤 기능을 개발했는지)
- [ ] TODO 2 (관련 API가 있다면 명시)
- [ ] TODO 3 (테스트 여부 등)

### 📸 테스트 결과 (선택)
> ✅ 하우스메이트 추가 동작 확인
![image](https://github.com/user-attachments/assets/78ee7419-5f38-41e0-8d2d-581adea1d93c)
✅ 하우스메이트 추가 / 점수 지급 확인
![image](https://github.com/user-attachments/assets/1c6b8db6-a720-442e-9b81-19c6957ca75e)
✅ mariaDB / Redis 팔로워 점수 지급 확인
![image](https://github.com/user-attachments/assets/7ffa2d1f-8810-495f-b6bc-e7130d9cbb80)
![image](https://github.com/user-attachments/assets/0a28ea8f-56a9-4414-913c-05d24994f6c2)
✅ UserActivityServiceTest 동작 확인
![image](https://github.com/user-attachments/assets/79c624cc-bbb3-4a72-93a7-6eb486338856)

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
