### PR TITLE
Feat/event/297 스케듈러를 통해 자동으로 이벤트 알림을 생성하여 웹소켓으로 사용자에게 전달

### DIFF
--- a/roome/src/main/java/com/roome/domain/event/notificationEvent/EventUpcomingNotificationEvent.java
+++ b/roome/src/main/java/com/roome/domain/event/notificationEvent/EventUpcomingNotificationEvent.java
@@ -1,0 +1,24 @@
+package com.roome.domain.event.notificationEvent;
+
+import com.roome.domain.notification.dto.NotificationType;
+import com.roome.global.notificationEvent.NotificationEvent;
+
+public class EventUpcomingNotificationEvent extends NotificationEvent {
+    private final Long eventId;
+
+    public EventUpcomingNotificationEvent(Object source, Long senderId, Long receiverId, Long eventId) {
+        super(source, senderId, receiverId);
+        this.eventId = eventId;
+    }
+
+    @Override
+    public Long getTargetId() {
+        // 이벤트 ID 반환, 프론트에서 알림 클릭 시 해당 이벤트 페이지로 이동할 때 사용
+        return eventId;
+    }
+
+    @Override
+    public NotificationType getType() {
+        return NotificationType.EVENT;
+    }
+}

--- a/roome/src/main/java/com/roome/domain/event/service/EventNotificationScheduler.java
+++ b/roome/src/main/java/com/roome/domain/event/service/EventNotificationScheduler.java
@@ -1,0 +1,71 @@
+package com.roome.domain.event.service;
+
+import com.roome.domain.event.entity.EventStatus;
+import com.roome.domain.event.entity.FirstComeEvent;
+import com.roome.domain.event.notificationEvent.EventUpcomingNotificationEvent;
+import com.roome.domain.event.repository.FirstComeEventRepository;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventNotificationScheduler {
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 시스템 사용자 ID (알림 발신자로 사용)
+    private static final Long SYSTEM_USER_ID = 0L;
+    // 모든 사용자에게 이벤트 알림 발송
+    @Scheduled(cron = "0 */30 * * * *")
+    public  void sendEventNotifications() {
+        log.info("이벤트 알림 발송 시작: 이벤트 ID={}, 이벤트명={}", "0", "선찬순 이벤트");
+        int page = 0;
+        boolean hasMoreUsers = true;
+        int pageSize = 100;
+        try {
+            // 모든 활성 사용자 조회 (실제 구현 시 적절한 필터링 조건 추가)
+            while (hasMoreUsers) {
+                PageRequest pageRequest = PageRequest.of(page, pageSize);
+                Page<User> userPage = userRepository.findAll(pageRequest);
+
+                if (userPage.isEmpty()) {
+                    hasMoreUsers = false;
+                    continue;
+                }
+
+                // 현재 페이지의 사용자들에게 알림 전송
+                for (User user : userPage.getContent()) {
+                    try {
+                        // 각 사용자에게 이벤트 알림 발행
+                        eventPublisher.publishEvent(new EventUpcomingNotificationEvent(
+                                this,
+                                SYSTEM_USER_ID,  // 발신자 (시스템)
+                                user.getId(),    // 수신자 (사용자)
+                                0L    // 이벤트 ID
+                        ));
+                        log.debug("사용자 알림 발행 성공: 사용자ID={}", user.getId());
+                    } catch (Exception e) {
+                        log.error("사용자 이벤트 알림 발행 실패: 사용자ID={}, 오류={}", user.getId(), e.getMessage());
+                        // 개별 사용자 알림 실패가 전체 프로세스를 중단하지 않도록 예외 처리
+                    }
+                }
+                page++;
+                hasMoreUsers = userPage.hasNext();
+            }
+
+            log.info("이벤트 알림 발송 완료: 모든 사용자에게 알림 전송");
+        } catch (Exception e) {
+            log.error("이벤트 알림 발송 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/roome/src/main/java/com/roome/domain/notification/entity/Notification.java
+++ b/roome/src/main/java/com/roome/domain/notification/entity/Notification.java
@@ -38,7 +38,7 @@ public class Notification extends BaseTimeEntity {
     private boolean isRead;
 
     @Builder
-    public Notification(NotificationType type, String title, String content,
+    public Notification(NotificationType type,
                         Long senderId, Long targetId, Long receiverId) {
         this.type = type;
         this.senderId = senderId;

--- a/roome/src/main/java/com/roome/domain/notification/listener/NotificationEventListener.java
+++ b/roome/src/main/java/com/roome/domain/notification/listener/NotificationEventListener.java
@@ -1,6 +1,7 @@
 package com.roome.domain.notification.listener;
 
 import com.roome.domain.cdcomment.notificationEvent.CdCommentCreatedEvent;
+import com.roome.domain.event.notificationEvent.EventUpcomingNotificationEvent;
 import com.roome.domain.guestbook.notificationEvent.GuestBookCreatedEvent;
 import com.roome.domain.houseMate.notificationEvent.HouseMateCreatedEvent;
 import com.roome.domain.notification.dto.CreateNotificationRequest;
@@ -127,6 +128,26 @@ public class NotificationEventListener {
             handleNotificationEvent(event);
         } catch (Exception e) {
             log.error("하우스메이트 알림 처리 중 오류 발생: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.NOTIFICATION_EVENT_PROCESSING_FAILED);
+        }
+    }
+
+    /// 이벤트 알림 전용 핸들러
+    @Async
+    @TransactionalEventListener(fallbackExecution = true)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleEventUpcoming(EventUpcomingNotificationEvent event) {
+        log.info("이벤트 알림 수신: 발신자={}, 수신자={}, 이벤트 ID={}",
+                event.getSenderId(), event.getReceiverId(), event.getTargetId());
+
+        try {
+            // 이벤트 특화 로직이 필요한 경우 여기에 추가
+            // 이벤트 알림이므로 별도 처리 없이 일반 알림으로 처리
+
+            // 일반 알림 처리로 위임
+            handleNotificationEvent(event);
+        } catch (Exception e) {
+            log.error("이벤트 알림 처리 중 오류 발생: {}", e.getMessage(), e);
             throw new BusinessException(ErrorCode.NOTIFICATION_EVENT_PROCESSING_FAILED);
         }
     }

--- a/roome/src/test/java/com/roome/domain/event/service/EventNotificationSchedulerTest.java
+++ b/roome/src/test/java/com/roome/domain/event/service/EventNotificationSchedulerTest.java
@@ -1,0 +1,179 @@
+package com.roome.domain.event.service;
+
+import com.roome.domain.event.notificationEvent.EventUpcomingNotificationEvent;
+import com.roome.domain.notification.dto.NotificationType;
+import com.roome.domain.notification.entity.Notification;
+import com.roome.domain.notification.listener.NotificationEventListener;
+import com.roome.domain.notification.repository.NotificationRepository;
+import com.roome.domain.notification.service.NotificationService;
+import com.roome.domain.notification.service.NotificationWebSocketService;
+import com.roome.domain.user.entity.Provider;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("이벤트 알림 스케줄러 테스트")
+class EventNotificationSchedulerTest {
+
+    @Autowired
+    private EventNotificationScheduler eventNotificationScheduler;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private NotificationWebSocketService notificationWebSocketService;
+
+    @MockBean
+    private NotificationEventListener notificationEventListener;
+
+    @MockBean
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+
+        // ApplicationEventPublisher를 목으로 대체
+        ReflectionTestUtils.setField(eventNotificationScheduler, "eventPublisher", applicationEventPublisher);
+    }
+
+    @Test
+    @DisplayName("모든 사용자에게 이벤트 알림이 정상적으로 생성되는지 확인")
+    void sendEventNotifications_CreatesNotificationsForAllUsers() throws InterruptedException {
+        // Arrange
+        LocalDateTime now = LocalDateTime.now();
+
+        User user1 = User.create(
+                "사용자1",
+                "닉네임1",
+                "user1@example.com",
+                "profile1.jpg",
+                Provider.GOOGLE,
+                "google-id-1",
+                now
+        );
+        user1.setId(1L);
+
+        User user2 = User.create(
+                "사용자2",
+                "닉네임2",
+                "user2@example.com",
+                "profile2.jpg",
+                Provider.KAKAO,
+                "kakao-id-2",
+                now
+        );
+        user2.setId(2L);
+
+        User user3 = User.create(
+                "사용자3",
+                "닉네임3",
+                "user3@example.com",
+                "profile3.jpg",
+                Provider.NAVER,
+                "naver-id-3",
+                now
+        );
+        user3.setId(3L);
+
+        List<User> users = Arrays.asList(user1, user2, user3);
+        Page<User> userPage = new PageImpl<>(users);
+
+        when(userRepository.findAll(any(PageRequest.class)))
+                .thenReturn(userPage);
+
+        // 이벤트 발행 시 직접 알림 생성
+        doAnswer(invocation -> {
+            EventUpcomingNotificationEvent event = invocation.getArgument(0);
+
+            // 발행된 이벤트로부터 알림 생성하여 저장
+            Notification notification = Notification.builder()
+                    .type(NotificationType.EVENT)
+                    .senderId(0L)
+                    .receiverId(event.getReceiverId())
+                    .targetId(0L).build();
+            notificationRepository.save(notification);
+
+            return null;
+        }).when(applicationEventPublisher).publishEvent(any(EventUpcomingNotificationEvent.class));
+
+        // Act
+        eventNotificationScheduler.sendEventNotifications();
+
+        // 비동기 처리를 위한 대기 시간
+        TimeUnit.SECONDS.sleep(1);
+
+        // Assert
+        List<Notification> notifications = notificationRepository.findAll();
+
+        // 사용자 수만큼의 알림이 생성되었는지 확인
+        assertEquals(3, notifications.size());
+
+        // 각 사용자에 대한 알림이 올바르게 생성되었는지 확인
+        for (Notification notification : notifications) {
+            assertEquals(NotificationType.EVENT, notification.getType());
+            assertEquals(0L, notification.getSenderId());
+            assertEquals(0L, notification.getTargetId());
+
+            // 수신자 ID가 유효한지 확인
+            Long receiverId = notification.getReceiverId();
+            assertTrue(receiverId == 1L || receiverId == 2L || receiverId == 3L);
+        }
+
+        // ApplicationEventPublisher가 3번 호출되었는지 확인
+        verify(applicationEventPublisher, times(3)).publishEvent(any(EventUpcomingNotificationEvent.class));
+    }
+
+    @Test
+    @DisplayName("사용자 목록이 비어있을 경우 알림이 생성되지 않는지 확인")
+    void sendEventNotifications_EmptyUserList_NoNotificationsCreated() throws InterruptedException {
+        // Arrange
+        Page<User> emptyPage = new PageImpl<>(List.of());
+
+        when(userRepository.findAll(any(PageRequest.class)))
+                .thenReturn(emptyPage);
+
+        // Act
+        eventNotificationScheduler.sendEventNotifications();
+
+        // 비동기 처리를 위한 대기 시간
+        TimeUnit.SECONDS.sleep(1);
+
+        // Assert
+        List<Notification> notifications = notificationRepository.findAll();
+        assertTrue(notifications.isEmpty());
+
+        // ApplicationEventPublisher가 호출되지 않았는지 확인
+        verify(applicationEventPublisher, never()).publishEvent(any(EventUpcomingNotificationEvent.class));
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
Feat/event/297 스케듈러를 통해 자동으로 이벤트 알림을 생성하여 웹소켓으로 사용자에게 전달

### 🏗 작업 내용
- [ ] feat: EventUpcomingNotificationEvent.java 이벤트 발생시 알림 생성을 위한 클래스 추가 chesthyeon 8분 전
- [ ] feat: EventNotificationScheduler.java 스케듈러를 통해 자동으로 알림을 생성하여 웹소켓으로 전달 chesthyeon 7분 전
- [ ] refactor: NotificationEventListener.java 수정 이벤트 알림 기능이 추가되서 파일 수정 chesthyeon 6분 전
- [ ] refactor: Notification.java 수정 불필요한 빌더 수정 chesthyeon 6분 전
- [ ] test: EventNotificationSchedulerTest.java 테스트 코드 추가 및 동작 확인 완료. chesthyeon 5분 전
- [ ] test: NotificationEventListenerTest.java 이벤트 리스너 변경 후 테스트 코드 수정 및 변경 chesthyeon 5분 전

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
