### PR TITLE
Fix: 포인트 내역 조회 시 firstId, lastId를 전체 기준으로 변경

### DIFF
--- a/roome/src/main/java/com/roome/domain/point/repository/PointHistoryRepository.java
+++ b/roome/src/main/java/com/roome/domain/point/repository/PointHistoryRepository.java
@@ -35,4 +35,11 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
       "AND ph.reason = :reason " +
       "AND ph.createdAt >= CURRENT_DATE")
   boolean existsRecentEarned(@Param("userId") Long userId, @Param("reason") PointReason reason);
+
+  @Query("SELECT MAX(ph.id) FROM PointHistory ph WHERE ph.user.id = :userId")
+  Long findFirstIdByUser(@Param("userId") Long userId);
+
+  @Query("SELECT MIN(ph.id) FROM PointHistory ph WHERE ph.user.id = :userId")
+  Long findLastIdByUser(@Param("userId") Long userId);
+
 }


### PR DESCRIPTION
## 📌 PR 제목 Fix: 포인트 내역 조회 시 firstId, lastId를 전체 기준으로 변경

### ✅ PR 설명
포인트 내역 조회 시 전체 데이터 기준의 firstId / lastId를 별도로 조회

### 🏗 작업 내용
- 기존에는 firstId와 lastId가 조회된 데이터 기준으로 설정됨
- firstId를 전체 포인트 내역 중 가장 최신 ID (MAX)로 설정
- lastId를 전체 포인트 내역 중 가장 오래된 ID (MIN)로 설정
- 관련 쿼리를 PointHistoryRepository에 추가하여 firstId/lastId 조회 처리

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> #306 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
