### PR TITLE
Feat/event/297 refactor: NotificationService.java 이벤트 알림의 경우 발신자 및 수신자 id 검증을 하지 않도록 수정 및 DB 초기화 셋팅

### DIFF
--- a/roome/src/main/java/com/roome/domain/notification/service/NotificationService.java
+++ b/roome/src/main/java/com/roome/domain/notification/service/NotificationService.java
@@ -8,12 +8,14 @@ import com.roome.domain.user.repository.UserRepository;
 import com.roome.global.exception.BusinessException;
 import com.roome.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NotificationService {
@@ -24,11 +26,16 @@ public class NotificationService {
     // 알림 생성 서비스
     @Transactional
     public Long createNotification(CreateNotificationRequest request) {
-        // 발신자와 수신자 존재 확인
-        userRepository.findById(request.getSenderId())
-                      .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        userRepository.findById(request.getReceiverId())
-                      .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if(request.getSenderId() == 0L){
+            log.info("시스템 알림이므로 발신자 및 수신자 ID를 검증하지 않습니다.");
+        } else {
+            // 발신자와 수신자 존재 확인
+            userRepository.findById(request.getSenderId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+            userRepository.findById(request.getReceiverId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+            log.info("발신자 및 수신자 ID가 존재합니다. snederId: {}, receiverId: {}", request.getSenderId(), request.getReceiverId());
+        }
 
         Notification notification = Notification.builder()
                                                 .type(request.getType())

--- a/roome/src/main/resources/application.yml
+++ b/roome/src/main/resources/application.yml
@@ -112,7 +112,7 @@ spring:
     password: ${DATASOURCE_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update  # create에서 update로 변경하여 기존 데이터 유지
+      ddl-auto: create-drop  # create에서 update로 변경하여 기존 데이터 유지
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     show-sql: true


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
refactor: NotificationService.java 이벤트 알림의 경우 발신자 및 수신자 id 검증을 하지 않도록 수정 chesthyeon 2분 전

### 🏗 작업 내용
- [ ] refactor: NotificationService.java 이벤트 알림의 경우 발신자 및 수신자 id 검증을 하지 않도록 수정 chesthyeon 2분 전

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
