### PR TITLE
feat: 유저 프로필 조회시에 장르 계산 서비스 개선

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   roome-app:
-    image: ${DOCKER_HUB_USERNAME}/roome:latest
+    image: ${DOCKER_HUB_USERNAME}/roome-prod:latest
     container_name: roome-prod
     ports:
       - "8081:8080"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   roome-app:
-    image: ${DOCKER_HUB_USERNAME}/roome-prod:latest
+    image: ${DOCKER_HUB_USERNAME}/roome:latest
     container_name: roome-prod
     ports:
       - "8081:8080"

--- a/roome/src/main/java/com/roome/domain/mybook/event/BookCollectionEvent.java
+++ b/roome/src/main/java/com/roome/domain/mybook/event/BookCollectionEvent.java
@@ -1,0 +1,28 @@
+package com.roome.domain.mybook.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public abstract class BookCollectionEvent extends ApplicationEvent {
+    private final Long userId;
+
+    public BookCollectionEvent(Object source, Long userId) {
+        super(source);
+        this.userId = userId;
+    }
+
+    // 책 추가 이벤트
+    public static class BookAddedEvent extends BookCollectionEvent {
+        public BookAddedEvent(Object source, Long userId) {
+            super(source, userId);
+        }
+    }
+
+    // 책 삭제 이벤트
+    public static class BookRemovedEvent extends BookCollectionEvent {
+        public BookRemovedEvent(Object source, Long userId) {
+            super(source, userId);
+        }
+    }
+}

--- a/roome/src/main/java/com/roome/domain/mycd/event/CdCollectionEvent.java
+++ b/roome/src/main/java/com/roome/domain/mycd/event/CdCollectionEvent.java
@@ -1,0 +1,28 @@
+package com.roome.domain.mycd.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public abstract class CdCollectionEvent extends ApplicationEvent {
+    private final Long userId;
+
+    public CdCollectionEvent(Object source, Long userId) {
+        super(source);
+        this.userId = userId;
+    }
+
+    //CD 추가 이벤트
+    public static class CdAddedEvent extends CdCollectionEvent {
+        public CdAddedEvent(Object source, Long userId) {
+            super(source, userId);
+        }
+    }
+
+    //CD 제거 이벤트
+    public static class CdRemovedEvent extends CdCollectionEvent {
+        public CdRemovedEvent(Object source, Long userId) {
+            super(source, userId);
+        }
+    }
+}

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -12,6 +12,7 @@ import com.roome.domain.mycd.dto.MyCdListResponse;
 import com.roome.domain.mycd.dto.MyCdResponse;
 import com.roome.domain.mycd.entity.MyCd;
 import com.roome.domain.mycd.entity.MyCdCount;
+import com.roome.domain.mycd.event.CdCollectionEvent;
 import com.roome.domain.mycd.exception.CdRackCapacityExceededException;
 import com.roome.domain.mycd.exception.MyCdAlreadyExistsException;
 import com.roome.domain.mycd.exception.MyCdDatabaseException;
@@ -33,6 +34,7 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -54,6 +56,7 @@ public class MyCdService {
   private final UserActivityService userActivityService;
   private final FurnitureService furnitureService;
   private final FurnitureCapacity furnitureCapacity;
+  private final ApplicationEventPublisher eventPublisher; // 이벤트 발행을 위해 추가
 
   public MyCdResponse addCdToMyList(Long userId, MyCdCreateRequest request) {
     User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
@@ -103,7 +106,9 @@ public class MyCdService {
 
     // 음악 등록 활동 기록 추가
     userActivityService.recordUserActivity(userId, ActivityType.MUSIC_REGISTRATION, cd.getId());
-
+    // 이벤트 발행
+    eventPublisher.publishEvent(new CdCollectionEvent.CdAddedEvent(this, userId));
+    log.debug("Published CD added event for user: {}", userId);
     return MyCdResponse.fromEntity(myCd);
   }
 
@@ -179,6 +184,9 @@ public class MyCdService {
 
     // 실제 삭제 수행
     myCdRepository.deleteByUserIdAndIds(userId, myCdIds);
+    //cd 삭제 후 이벤트 발행
+    eventPublisher.publishEvent(new CdCollectionEvent.CdRemovedEvent(this, userId));
+    log.debug("Published CD removed event for user: {}", userId);
   }
 
 }

--- a/roome/src/main/java/com/roome/domain/user/service/UserProfileService.java
+++ b/roome/src/main/java/com/roome/domain/user/service/UserProfileService.java
@@ -1,15 +1,12 @@
 package com.roome.domain.user.service;
 
 import com.roome.domain.houseMate.repository.HousemateRepository;
-import com.roome.domain.mybook.entity.MyBook;
-import com.roome.domain.mybook.entity.repository.MyBookRepository;
-import com.roome.domain.mycd.entity.MyCd;
-import com.roome.domain.mycd.repository.MyCdRepository;
 import com.roome.domain.user.dto.RecommendedUserDto;
 import com.roome.domain.user.dto.request.UpdateProfileRequest;
 import com.roome.domain.user.dto.response.UserProfileResponse;
 import com.roome.domain.user.entity.User;
 import com.roome.domain.user.repository.UserRepository;
+import com.roome.domain.userGenrePreference.service.GenrePreferenceService;
 import com.roome.global.exception.BusinessException;
 import com.roome.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -30,21 +27,23 @@ import java.util.stream.Collectors;
 public class UserProfileService {
 
     private final UserRepository userRepository;
-    private final MyCdRepository myCdRepository;
-    private final MyBookRepository myBookRepository;
     private final HousemateRepository housemateRepository;
+    private final GenrePreferenceService genrePreferenceService;
 
     public UserProfileResponse getUserProfile(Long userId, Long authUserId) {
         // 사용자 정보 한 번만 조회
         User targetUser = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        // 1. CD 장르 상위 3개 가져오기
-        List<String> topCdGenres = getTopCdGenres(userId);
-        // 2. 책 장르 상위 3개 가져오기
-        List<String> topBookGenres = getTopBookGenres(userId);
-        // 3. 유사한 취향을 가진 사용자 추천
+        // 1. CD 장르 상위 3개 가져오기 - 저장된 선호도 사용
+        List<String> topCdGenres = genrePreferenceService.getTopCdGenres(userId);
+
+        // 2. 책 장르 상위 3개 가져오기 - 저장된 선호도 사용
+        List<String> topBookGenres = genrePreferenceService.getTopBookGenres(userId);
+
+        // 3. 유사한 취향을 가진 사용자 추천 - 기존 방식 유지 (나중에 업데이트 예정)
         List<User> recommendedUsers = recommendSimilarUsers(userId);
+
         // 4. DTO로 변환
         List<RecommendedUserDto> recommendedUserDtoList = recommendedUsers.stream()
                 .map(user -> RecommendedUserDto.builder()
@@ -58,7 +57,6 @@ public class UserProfileService {
         if (!targetUser.getId().equals(authUserId)) { // 자기 자신이 아닌 경우만 확인
             isFollowing = housemateRepository.existsByUserIdAndAddedId(authUserId, userId);
         }
-
 
         // 5. 응답 DTO 생성
         return UserProfileResponse.builder()
@@ -83,67 +81,12 @@ public class UserProfileService {
         return getUserProfile(userId, userId);
     }
 
-
-    private List<String> getTopCdGenres(Long userId) {
-        // 1. 사용자의 모든 CD 가져오기
-        List<MyCd> userCds = myCdRepository.findByUserId(userId);
-
-        if (userCds.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        // 2. 장르 카운팅
-        Map<String, Long> genreCounts = new HashMap<>();
-        for (MyCd myCd : userCds) {
-            List<String> genres = myCd.getCd().getGenres();
-            for (String genre : genres) {
-                genreCounts.put(genre, genreCounts.getOrDefault(genre, 0L) + 1);
-            }
-        }
-
-        // 3. 상위 3개 장르 반환
-        return genreCounts.entrySet().stream()
-                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-                .limit(3)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
-    }
-
-    // 사용자의 책 컬렉션에서 상위 3개 장르 찾기
-    private List<String> getTopBookGenres(Long userId) {
-        // 1. 사용자의 모든 책 가져오기
-        List<MyBook> userBooks = myBookRepository.findAllByUserId(userId);
-
-        if (userBooks.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        // 2. 장르 카운팅
-        Map<String, Long> genreCounts = new HashMap<>();
-        for (MyBook myBook : userBooks) {
-            // Book 엔티티에서 장르 정보를 가져오는 방식에 따라 코드 조정 필요
-            List<String> genres = myBook.getBook().getBookGenres().stream()
-                    .map(bg -> bg.getGenre().getName())
-                    .collect(Collectors.toList());
-
-            for (String genre : genres) {
-                genreCounts.put(genre, genreCounts.getOrDefault(genre, 0L) + 1);
-            }
-        }
-
-        // 3. 상위 3개 장르 반환
-        return genreCounts.entrySet().stream()
-                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-                .limit(3)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
-    }
-
-    // 유사한 취향을 가진 사용자 추천
+    // 나중에 업데이트 예정인 추천 로직은 그대로 유지
+    // TODO: 추후 리팩토링 예정
     private List<User> recommendSimilarUsers(Long userId) {
         // 1. 현재 사용자의 선호 장르 가져오기
-        List<String> topCdGenres = getTopCdGenres(userId);
-        List<String> topBookGenres = getTopBookGenres(userId);
+        List<String> topCdGenres = genrePreferenceService.getTopCdGenres(userId);
+        List<String> topBookGenres = genrePreferenceService.getTopBookGenres(userId);
 
         // 선호 장르가 없으면 빈 리스트 반환
         if (topCdGenres.isEmpty() && topBookGenres.isEmpty()) {
@@ -160,7 +103,7 @@ public class UserProfileService {
             int score = 0;
 
             // CD 장르 유사도
-            List<String> otherCdGenres = getTopCdGenres(otherUser.getId());
+            List<String> otherCdGenres = genrePreferenceService.getTopCdGenres(otherUser.getId());
             for (String genre : topCdGenres) {
                 if (otherCdGenres.contains(genre)) {
                     score += 1;
@@ -168,7 +111,7 @@ public class UserProfileService {
             }
 
             // 책 장르 유사도
-            List<String> otherBookGenres = getTopBookGenres(otherUser.getId());
+            List<String> otherBookGenres = genrePreferenceService.getTopBookGenres(otherUser.getId());
             for (String genre : topBookGenres) {
                 if (otherBookGenres.contains(genre)) {
                     score += 1;

--- a/roome/src/main/java/com/roome/domain/userGenrePreference/entity/GenreType.java
+++ b/roome/src/main/java/com/roome/domain/userGenrePreference/entity/GenreType.java
@@ -1,0 +1,13 @@
+package com.roome.domain.userGenrePreference.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GenreType {
+    CD("CD"),
+    BOOK("Book");
+
+    private final String type;
+}

--- a/roome/src/main/java/com/roome/domain/userGenrePreference/entity/UserGenrePreference.java
+++ b/roome/src/main/java/com/roome/domain/userGenrePreference/entity/UserGenrePreference.java
@@ -1,0 +1,55 @@
+package com.roome.domain.userGenrePreference.entity;
+
+import com.roome.domain.user.entity.User;
+import com.roome.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "user_genre_preferences",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "genre_type", "rank"}))
+public class UserGenrePreference extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "genre_type", nullable = false, length = 10)
+    private GenreType genreType;
+
+    @Column(nullable = false, length = 50)
+    private String genreName;
+
+    @Column(nullable = false)
+    private Integer count;
+
+    @Column(nullable = false)
+    private Integer rank;
+
+    public void updateCount(Integer count) {
+        this.count = count;
+    }
+
+    public void updateRank(Integer rank) {
+        this.rank = rank;
+    }
+
+    public static UserGenrePreference create(User user, GenreType genreType, String genreName, Integer count, Integer rank) {
+        return UserGenrePreference.builder()
+                .user(user)
+                .genreType(genreType)
+                .genreName(genreName)
+                .count(count)
+                .rank(rank)
+                .build();
+    }
+}

--- a/roome/src/main/java/com/roome/domain/userGenrePreference/listner/GenrePreferenceEventListener.java
+++ b/roome/src/main/java/com/roome/domain/userGenrePreference/listner/GenrePreferenceEventListener.java
@@ -1,0 +1,55 @@
+package com.roome.domain.userGenrePreference.listner;
+
+import com.roome.domain.mybook.event.BookCollectionEvent;
+import com.roome.domain.mycd.event.CdCollectionEvent;
+import com.roome.domain.userGenrePreference.service.GenrePreferenceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GenrePreferenceEventListener {
+
+    private final GenrePreferenceService genrePreferenceService;
+
+    // CD 추가 이벤트 리스너
+    @Async("taskExecutor")
+    @EventListener
+    @Transactional
+    public void handleCdAddedEvent(CdCollectionEvent.CdAddedEvent event) {
+        log.info("Handling CD added event for user: {}", event.getUserId());
+        genrePreferenceService.updateCdGenrePreferences(event.getUserId());
+    }
+
+    // CD 제거 이벤트 리스너
+    @Async("taskExecutor")
+    @EventListener
+    @Transactional
+    public void handleCdRemovedEvent(CdCollectionEvent.CdRemovedEvent event) {
+        log.info("Handling CD removed event for user: {}", event.getUserId());
+        genrePreferenceService.updateCdGenrePreferences(event.getUserId());
+    }
+
+    // 책 추가 이벤트 리스너
+    @Async("taskExecutor")
+    @EventListener
+    @Transactional
+    public void handleBookAddedEvent(BookCollectionEvent.BookAddedEvent event) {
+        log.info("Handling Book added event for user: {}", event.getUserId());
+        genrePreferenceService.updateBookGenrePreferences(event.getUserId());
+    }
+
+    // 책 제거 이벤트 리스너
+    @Async("taskExecutor")
+    @EventListener
+    @Transactional
+    public void handleBookRemovedEvent(BookCollectionEvent.BookRemovedEvent event) {
+        log.info("Handling Book removed event for user: {}", event.getUserId());
+        genrePreferenceService.updateBookGenrePreferences(event.getUserId());
+    }
+}

--- a/roome/src/main/java/com/roome/domain/userGenrePreference/repository/UserGenrePreferenceRepository.java
+++ b/roome/src/main/java/com/roome/domain/userGenrePreference/repository/UserGenrePreferenceRepository.java
@@ -1,0 +1,30 @@
+package com.roome.domain.userGenrePreference.repository;
+
+import com.roome.domain.userGenrePreference.entity.GenreType;
+import com.roome.domain.userGenrePreference.entity.UserGenrePreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserGenrePreferenceRepository extends JpaRepository<UserGenrePreference, Long> {
+
+    // 사용자 ID와 장르 타입으로 장르 선호도 조회 (rank 오름차순)
+    List<UserGenrePreference> findByUserIdAndGenreTypeOrderByRankAsc(Long userId, GenreType genreType);
+
+    // 사용자 ID로 모든 장르 선호도 조회 (장르 타입, rank 오름차순)
+    List<UserGenrePreference> findByUserIdOrderByGenreTypeAscRankAsc(Long userId);
+
+    // 사용자 ID와 장르 타입으로 모든 장르 선호도 삭제
+    void deleteByUserIdAndGenreType(Long userId, GenreType genreType);
+
+    // 특정 장르를 선호하는 다른 사용자 찾기 (자신 제외)
+    @Query("SELECT up.user.id FROM UserGenrePreference up " +
+            "WHERE up.genreName = :genreName AND up.genreType = :genreType " +
+            "AND up.user.id != :userId")
+    List<Long> findUserIdsByGenreNameAndGenreTypeAndUserIdNot(
+            @Param("genreName") String genreName,
+            @Param("genreType") GenreType genreType,
+            @Param("userId") Long userId);
+}

--- a/roome/src/main/java/com/roome/domain/userGenrePreference/service/GenrePreferenceService.java
+++ b/roome/src/main/java/com/roome/domain/userGenrePreference/service/GenrePreferenceService.java
@@ -1,0 +1,137 @@
+package com.roome.domain.userGenrePreference.service;
+
+import com.roome.domain.mybook.entity.MyBook;
+import com.roome.domain.mybook.entity.repository.MyBookRepository;
+import com.roome.domain.mycd.entity.MyCd;
+import com.roome.domain.mycd.repository.MyCdRepository;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import com.roome.domain.userGenrePreference.entity.GenreType;
+import com.roome.domain.userGenrePreference.entity.UserGenrePreference;
+import com.roome.domain.userGenrePreference.repository.UserGenrePreferenceRepository;
+import com.roome.global.exception.BusinessException;
+import com.roome.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GenrePreferenceService {
+
+    private final UserRepository userRepository;
+    private final MyCdRepository myCdRepository;
+    private final MyBookRepository myBookRepository;
+    private final UserGenrePreferenceRepository userGenrePreferenceRepository;
+
+    // 사용자의 CD 장르 선호도 조회
+    public List<String> getTopCdGenres(Long userId) {
+        return userGenrePreferenceRepository
+                .findByUserIdAndGenreTypeOrderByRankAsc(userId, GenreType.CD)
+                .stream()
+                .map(UserGenrePreference::getGenreName)
+                .collect(Collectors.toList());
+    }
+
+    // 사용자의 책 장르 선호도 조회
+    public List<String> getTopBookGenres(Long userId) {
+        return userGenrePreferenceRepository
+                .findByUserIdAndGenreTypeOrderByRankAsc(userId, GenreType.BOOK)
+                .stream()
+                .map(UserGenrePreference::getGenreName)
+                .collect(Collectors.toList());
+    }
+
+    // CD 장르 선호도 계산 및 업데이트
+    @Transactional
+    public void updateCdGenrePreferences(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        List<MyCd> userCds = myCdRepository.findByUserId(userId);
+
+        if (userCds.isEmpty()) {
+            // 선호도가 있으면 삭제
+            userGenrePreferenceRepository.deleteByUserIdAndGenreType(userId, GenreType.CD);
+            return;
+        }
+
+        // 장르 카운팅
+        Map<String, Integer> genreCounts = new HashMap<>();
+        for (MyCd myCd : userCds) {
+            List<String> genres = myCd.getCd().getGenres();
+            for (String genre : genres) {
+                genreCounts.put(genre, genreCounts.getOrDefault(genre, 0) + 1);
+            }
+        }
+
+        // 상위 3개 장르 선별
+        List<Map.Entry<String, Integer>> topGenres = genreCounts.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .limit(3)
+                .collect(Collectors.toList());
+
+        // 기존 선호도 삭제
+        userGenrePreferenceRepository.deleteByUserIdAndGenreType(userId, GenreType.CD);
+
+        // 새 선호도 저장
+        for (int i = 0; i < topGenres.size(); i++) {
+            Map.Entry<String, Integer> entry = topGenres.get(i);
+            UserGenrePreference preference = UserGenrePreference.create(
+                    user, GenreType.CD, entry.getKey(), entry.getValue(), i + 1
+            );
+            userGenrePreferenceRepository.save(preference);
+        }
+    }
+
+    // 책 장르 선호도 계산 및 업데이트
+    @Transactional
+    public void updateBookGenrePreferences(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        List<MyBook> userBooks = myBookRepository.findAllByUserId(userId);
+
+        if (userBooks.isEmpty()) {
+            // 선호도가 있으면 삭제
+            userGenrePreferenceRepository.deleteByUserIdAndGenreType(userId, GenreType.BOOK);
+            return;
+        }
+
+        // 장르 카운팅
+        Map<String, Integer> genreCounts = new HashMap<>();
+        for (MyBook myBook : userBooks) {
+            List<String> genres = myBook.getBook().getBookGenres().stream()
+                    .map(bg -> bg.getGenre().getName())
+                    .collect(Collectors.toList());
+
+            for (String genre : genres) {
+                genreCounts.put(genre, genreCounts.getOrDefault(genre, 0) + 1);
+            }
+        }
+
+        // 상위 3개 장르 선별
+        List<Map.Entry<String, Integer>> topGenres = genreCounts.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .limit(3)
+                .collect(Collectors.toList());
+
+        // 기존 선호도 삭제
+        userGenrePreferenceRepository.deleteByUserIdAndGenreType(userId, GenreType.BOOK);
+
+        // 새 선호도 저장
+        for (int i = 0; i < topGenres.size(); i++) {
+            Map.Entry<String, Integer> entry = topGenres.get(i);
+            UserGenrePreference preference = UserGenrePreference.create(
+                    user, GenreType.BOOK, entry.getKey(), entry.getValue(), i + 1
+            );
+            userGenrePreferenceRepository.save(preference);
+        }
+    }
+}

--- a/roome/src/test/java/com/roome/domain/userGenrePreference/listner/GenrePreferenceEventListenerTest.java
+++ b/roome/src/test/java/com/roome/domain/userGenrePreference/listner/GenrePreferenceEventListenerTest.java
@@ -1,0 +1,79 @@
+package com.roome.domain.userGenrePreference.listner;
+
+import com.roome.domain.mybook.event.BookCollectionEvent;
+import com.roome.domain.mycd.event.CdCollectionEvent;
+import com.roome.domain.userGenrePreference.service.GenrePreferenceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GenrePreferenceEventListenerTest {
+
+    @Mock
+    private GenrePreferenceService genrePreferenceService;
+
+    @InjectMocks
+    private GenrePreferenceEventListener eventListener;
+
+    @Test
+    @DisplayName("CD 추가 이벤트 처리 성공")
+    void handleCdAddedEvent_ShouldCallUpdateCdGenrePreferences() {
+        // Given
+        Long userId = 1L;
+        CdCollectionEvent.CdAddedEvent event = new CdCollectionEvent.CdAddedEvent(this, userId);
+
+        // When
+        eventListener.handleCdAddedEvent(event);
+
+        // Then
+        verify(genrePreferenceService).updateCdGenrePreferences(userId);
+    }
+
+    @Test
+    @DisplayName("CD 제거 이벤트 처리 성공")
+    void handleCdRemovedEvent_ShouldCallUpdateCdGenrePreferences() {
+        // Given
+        Long userId = 1L;
+        CdCollectionEvent.CdRemovedEvent event = new CdCollectionEvent.CdRemovedEvent(this, userId);
+
+        // When
+        eventListener.handleCdRemovedEvent(event);
+
+        // Then
+        verify(genrePreferenceService).updateCdGenrePreferences(userId);
+    }
+
+    @Test
+    @DisplayName("책 추가 이벤트 처리 성공")
+    void handleBookAddedEvent_ShouldCallUpdateBookGenrePreferences() {
+        // Given
+        Long userId = 1L;
+        BookCollectionEvent.BookAddedEvent event = new BookCollectionEvent.BookAddedEvent(this, userId);
+
+        // When
+        eventListener.handleBookAddedEvent(event);
+
+        // Then
+        verify(genrePreferenceService).updateBookGenrePreferences(userId);
+    }
+
+    @Test
+    @DisplayName("책 제거 이벤트 처리 성공")
+    void handleBookRemovedEvent_ShouldCallUpdateBookGenrePreferences() {
+        // Given
+        Long userId = 1L;
+        BookCollectionEvent.BookRemovedEvent event = new BookCollectionEvent.BookRemovedEvent(this, userId);
+
+        // When
+        eventListener.handleBookRemovedEvent(event);
+
+        // Then
+        verify(genrePreferenceService).updateBookGenrePreferences(userId);
+    }
+}

--- a/roome/src/test/java/com/roome/domain/userGenrePreference/service/GenrePreferenceServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/userGenrePreference/service/GenrePreferenceServiceTest.java
@@ -1,0 +1,289 @@
+package com.roome.domain.userGenrePreference.service;
+
+import com.roome.domain.book.entity.Book;
+import com.roome.domain.book.entity.BookGenre;
+import com.roome.domain.book.entity.Genre;
+import com.roome.domain.cd.entity.Cd;
+import com.roome.domain.cd.entity.CdGenre;
+import com.roome.domain.cd.entity.CdGenreType;
+import com.roome.domain.mybook.entity.MyBook;
+import com.roome.domain.mybook.entity.repository.MyBookRepository;
+import com.roome.domain.mycd.entity.MyCd;
+import com.roome.domain.mycd.repository.MyCdRepository;
+import com.roome.domain.room.entity.Room;
+import com.roome.domain.user.entity.User;
+import com.roome.domain.user.repository.UserRepository;
+import com.roome.domain.userGenrePreference.entity.GenreType;
+import com.roome.domain.userGenrePreference.entity.UserGenrePreference;
+import com.roome.domain.userGenrePreference.repository.UserGenrePreferenceRepository;
+import com.roome.global.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GenrePreferenceServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MyCdRepository myCdRepository;
+
+    @Mock
+    private MyBookRepository myBookRepository;
+
+    @Mock
+    private UserGenrePreferenceRepository userGenrePreferenceRepository;
+
+    @InjectMocks
+    private GenrePreferenceService genrePreferenceService;
+
+    private User testUser;
+    private MyCd testMyCd1, testMyCd2, testMyCd3;
+    private MyBook testMyBook1, testMyBook2, testMyBook3;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .name("Test User")
+                .nickname("testuser")
+                .build();
+
+        // CD 설정
+        Cd cd1 = createCd(1L, "Album 1", "Artist 1", List.of("Pop", "Rock"));
+        Cd cd2 = createCd(2L, "Album 2", "Artist 2", List.of("Rock", "Metal"));
+        Cd cd3 = createCd(3L, "Album 3", "Artist 3", List.of("Pop", "Jazz"));
+
+        Room room = Room.builder().id(1L).user(testUser).build();
+
+        testMyCd1 = MyCd.create(testUser, room, cd1);
+        testMyCd2 = MyCd.create(testUser, room, cd2);
+        testMyCd3 = MyCd.create(testUser, room, cd3);
+
+        // Book 설정
+        Book book1 = createBook(1L, "Book 1", "Author 1", List.of("Fiction", "Fantasy"));
+        Book book2 = createBook(2L, "Book 2", "Author 2", List.of("Fiction", "Sci-Fi"));
+        Book book3 = createBook(3L, "Book 3", "Author 3", List.of("Non-Fiction", "Biography"));
+
+        testMyBook1 = MyBook.create(testUser, room, book1);
+        testMyBook2 = MyBook.create(testUser, room, book2);
+        testMyBook3 = MyBook.create(testUser, room, book3);
+    }
+
+    @Test
+    @DisplayName("CD 장르 선호도 조회 성공")
+    void getTopCdGenres_ShouldReturnGenreList() {
+        // Given
+        List<UserGenrePreference> preferences = Arrays.asList(
+                UserGenrePreference.create(testUser, GenreType.CD, "Rock", 2, 1),
+                UserGenrePreference.create(testUser, GenreType.CD, "Pop", 2, 2),
+                UserGenrePreference.create(testUser, GenreType.CD, "Jazz", 1, 3)
+        );
+
+        when(userGenrePreferenceRepository.findByUserIdAndGenreTypeOrderByRankAsc(
+                eq(1L), eq(GenreType.CD))).thenReturn(preferences);
+
+        // When
+        List<String> result = genrePreferenceService.getTopCdGenres(1L);
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly("Rock", "Pop", "Jazz");
+        verify(userGenrePreferenceRepository).findByUserIdAndGenreTypeOrderByRankAsc(
+                eq(1L), eq(GenreType.CD));
+    }
+
+    @Test
+    @DisplayName("책 장르 선호도 조회 성공")
+    void getTopBookGenres_ShouldReturnGenreList() {
+        // Given
+        List<UserGenrePreference> preferences = Arrays.asList(
+                UserGenrePreference.create(testUser, GenreType.BOOK, "Fiction", 2, 1),
+                UserGenrePreference.create(testUser, GenreType.BOOK, "Fantasy", 1, 2),
+                UserGenrePreference.create(testUser, GenreType.BOOK, "Sci-Fi", 1, 3)
+        );
+
+        when(userGenrePreferenceRepository.findByUserIdAndGenreTypeOrderByRankAsc(
+                eq(1L), eq(GenreType.BOOK))).thenReturn(preferences);
+
+        // When
+        List<String> result = genrePreferenceService.getTopBookGenres(1L);
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly("Fiction", "Fantasy", "Sci-Fi");
+        verify(userGenrePreferenceRepository).findByUserIdAndGenreTypeOrderByRankAsc(
+                eq(1L), eq(GenreType.BOOK));
+    }
+
+    @Test
+    @DisplayName("CD 장르 선호도 업데이트 성공 - CD가 있는 경우")
+    void updateCdGenrePreferences_WithCds_ShouldSavePreferences() {
+        // Given
+        Long userId = 1L;
+        List<MyCd> myCds = Arrays.asList(testMyCd1, testMyCd2, testMyCd3);
+
+        when(userRepository.findById(eq(userId))).thenReturn(Optional.of(testUser));
+        when(myCdRepository.findByUserId(eq(userId))).thenReturn(myCds);
+
+        // When
+        genrePreferenceService.updateCdGenrePreferences(userId);
+
+        // Then
+        verify(userRepository).findById(eq(userId));
+        verify(myCdRepository).findByUserId(eq(userId));
+        verify(userGenrePreferenceRepository).deleteByUserIdAndGenreType(eq(userId), eq(GenreType.CD));
+        verify(userGenrePreferenceRepository, times(3)).save(any(UserGenrePreference.class));
+    }
+
+    @Test
+    @DisplayName("CD 장르 선호도 업데이트 - CD가 없는 경우")
+    void updateCdGenrePreferences_WithoutCds_ShouldDeleteExistingPreferences() {
+        // Given
+        Long userId = 1L;
+        List<MyCd> myCds = Collections.emptyList();
+
+        when(userRepository.findById(eq(userId))).thenReturn(Optional.of(testUser));
+        when(myCdRepository.findByUserId(eq(userId))).thenReturn(myCds);
+
+        // When
+        genrePreferenceService.updateCdGenrePreferences(userId);
+
+        // Then
+        verify(userRepository).findById(eq(userId));
+        verify(myCdRepository).findByUserId(eq(userId));
+        verify(userGenrePreferenceRepository).deleteByUserIdAndGenreType(eq(userId), eq(GenreType.CD));
+        verify(userGenrePreferenceRepository, never()).save(any(UserGenrePreference.class));
+    }
+
+    @Test
+    @DisplayName("책 장르 선호도 업데이트 성공 - 책이 있는 경우")
+    void updateBookGenrePreferences_WithBooks_ShouldSavePreferences() {
+        // Given
+        Long userId = 1L;
+        List<MyBook> myBooks = Arrays.asList(testMyBook1, testMyBook2, testMyBook3);
+
+        when(userRepository.findById(eq(userId))).thenReturn(Optional.of(testUser));
+        when(myBookRepository.findAllByUserId(eq(userId))).thenReturn(myBooks);
+
+        // When
+        genrePreferenceService.updateBookGenrePreferences(userId);
+
+        // Then
+        verify(userRepository).findById(eq(userId));
+        verify(myBookRepository).findAllByUserId(eq(userId));
+        verify(userGenrePreferenceRepository).deleteByUserIdAndGenreType(eq(userId), eq(GenreType.BOOK));
+        verify(userGenrePreferenceRepository, times(3)).save(any(UserGenrePreference.class));
+    }
+
+    @Test
+    @DisplayName("책 장르 선호도 업데이트 - 책이 없는 경우")
+    void updateBookGenrePreferences_WithoutBooks_ShouldDeleteExistingPreferences() {
+        // Given
+        Long userId = 1L;
+        List<MyBook> myBooks = Collections.emptyList();
+
+        when(userRepository.findById(eq(userId))).thenReturn(Optional.of(testUser));
+        when(myBookRepository.findAllByUserId(eq(userId))).thenReturn(myBooks);
+
+        // When
+        genrePreferenceService.updateBookGenrePreferences(userId);
+
+        // Then
+        verify(userRepository).findById(eq(userId));
+        verify(myBookRepository).findAllByUserId(eq(userId));
+        verify(userGenrePreferenceRepository).deleteByUserIdAndGenreType(eq(userId), eq(GenreType.BOOK));
+        verify(userGenrePreferenceRepository, never()).save(any(UserGenrePreference.class));
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않을 때 예외 발생")
+    void updateCdGenrePreferences_WithNonExistingUser_ShouldThrowException() {
+        // Given
+        Long userId = 999L;
+        when(userRepository.findById(eq(userId))).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(BusinessException.class, () -> {
+            genrePreferenceService.updateCdGenrePreferences(userId);
+        });
+
+        verify(userRepository).findById(eq(userId));
+        verify(myCdRepository, never()).findByUserId(any());
+    }
+
+    // Helper methods
+    private Cd createCd(Long id, String title, String artist, List<String> genreNames) {
+        Cd cd = Cd.builder()
+                .id(id)
+                .title(title)
+                .artist(artist)
+                .build();
+
+        List<CdGenre> cdGenres = new ArrayList<>();
+        for (String genreName : genreNames) {
+            // CdGenreType 객체 생성 및 설정
+            CdGenreType genreType = CdGenreType.builder()
+                    .id((long) genreNames.indexOf(genreName) + 1)
+                    .name(genreName)
+                    .build();
+
+            // CdGenre 객체 생성 및 연결
+            CdGenre cdGenre = CdGenre.builder()
+                    .cd(cd)
+                    .genreType(genreType)
+                    .build();
+
+            cdGenres.add(cdGenre);
+        }
+
+        // CD에 장르 추가
+        for (CdGenre cdGenre : cdGenres) {
+            cd.addGenre(cdGenre);
+        }
+        return cd;
+    }
+
+    private Book createBook(Long id, String title, String author, List<String> genreNames) {
+        Book book = Book.builder()
+                .id(id)
+                .title(title)
+                .author(author)
+                .build();
+
+        List<BookGenre> bookGenres = new ArrayList<>();
+        for (String genreName : genreNames) {
+            // Genre 객체 생성 (Genre.create 메소드 사용)
+            // 실제 서비스에서는 ID가 자동 생성되므로 여기서는 설정하지 않음
+            Genre genre = Genre.create(genreName);
+
+            // BookGenre 객체 생성 및 연결
+            BookGenre bookGenre = BookGenre.builder()
+                    .book(book)
+                    .genre(genre)
+                    .build();
+            bookGenres.add(bookGenre);
+        }
+
+        // Book에 장르 추가
+        for (BookGenre bookGenre : bookGenres) {
+            book.addBookGenre(bookGenre);
+        }
+        return book;
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
 유저 프로필 조회시에 장르 계산 서비스 개선
### 🏗 작업 내용
- [ ] refactor: 사용자 장르 테이블을 구현 chesthyeon 오늘 오후 12:52
- [ ] feat: cd,book 추가시 사용자 장르를 업데이트 하기 위한 이벤트 클래스 생성 chesthyeon 38분 전
- [ ] feat: GenrePreferenceEventListener.java, GenrePreferenceService.java 이벤트가 발행 되었을 때 이벤트를 읽을 리스너와, 이벤트 리스너에서 사용할 서비스 코드 추가 chesthyeon 37분 전
- [ ] refactor: MyBookService.java, MyCdService.java 각 책 음악이 삭제 되었을 때 이벤트를 발행하도록 수정. chesthyeon 37분 전
- [ ] refactor: UserProfileService.java. 프로파일 장르 선호 로직을 수정 chesthyeon 36분 전
- [ ] test: GenrePreferenceEventListenerTest.java, GenrePreferenceServiceTest.java 테스트 추가 후 동작 확인 완료. chesthyeon 36분 전
 

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
