### PR TITLE
Feat: QueryDSL 기반 검색 기능 추가 및 성능 최적화

### DIFF
--- a/roome/src/main/java/com/roome/domain/mycd/repository/MyCdQueryRepository.java
+++ b/roome/src/main/java/com/roome/domain/mycd/repository/MyCdQueryRepository.java
@@ -1,0 +1,9 @@
+package com.roome.domain.mycd.repository;
+
+import com.roome.domain.mycd.entity.MyCd;
+import org.springframework.data.domain.Page;
+
+public interface MyCdQueryRepository {
+
+  Page<MyCd> searchMyCd(Long userId, String keyword, Long cursor, int size);
+}

--- a/roome/src/main/java/com/roome/domain/mycd/repository/MyCdQueryRepositoryImpl.java
+++ b/roome/src/main/java/com/roome/domain/mycd/repository/MyCdQueryRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.roome.domain.mycd.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.roome.domain.cd.entity.QCd;
+import com.roome.domain.mycd.entity.MyCd;
+import com.roome.domain.mycd.entity.QMyCd;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+@RequiredArgsConstructor
+public class MyCdQueryRepositoryImpl implements MyCdQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<MyCd> searchMyCd(Long userId, String keyword, Long cursor, int size) {
+    QMyCd myCd = QMyCd.myCd;
+    QCd cd = QCd.cd;
+
+    List<MyCd> result = queryFactory
+        .selectFrom(myCd)
+        .join(myCd.cd, cd)
+        .where(myCd.user.id.eq(userId)
+            .and(cursor != null ? myCd.id.gt(cursor) : null)
+            .and(keyword != null ? cd.title.containsIgnoreCase(keyword)
+                .or(cd.artist.containsIgnoreCase(keyword)) : null))
+        .orderBy(myCd.id.asc())
+        .limit(size)
+        .fetch();
+
+    return new PageImpl<>(result);
+  }
+}

--- a/roome/src/main/java/com/roome/domain/mycd/repository/MyCdRepository.java
+++ b/roome/src/main/java/com/roome/domain/mycd/repository/MyCdRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface MyCdRepository extends JpaRepository<MyCd, Long> {
+public interface MyCdRepository extends JpaRepository<MyCd, Long>, MyCdQueryRepository {
 
   boolean existsById(Long id);
 
@@ -29,13 +29,6 @@ public interface MyCdRepository extends JpaRepository<MyCd, Long> {
   Optional<MyCd> findFirstByUserIdOrderByIdAsc(Long userId);
 
   Optional<MyCd> findFirstByUserIdOrderByIdDesc(Long userId);
-
-  // 키워드 기반 검색 (CD 제목 또는 가수명)
-  @Query("SELECT mc FROM MyCd mc JOIN mc.cd c " + "WHERE mc.user.id = :userId "
-      + "AND (LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) "
-      + "OR LOWER(c.artist) LIKE LOWER(CONCAT('%', :keyword, '%'))) " + "ORDER BY mc.id ASC")
-  Page<MyCd> searchByUserIdAndKeyword(@Param("userId") Long userId,
-      @Param("keyword") String keyword, Pageable pageable);
 
   @Modifying
   @Query("DELETE FROM MyCd mc WHERE mc.user.id = :userId AND mc.id IN (:ids)")

--- a/roome/src/main/java/com/roome/domain/mycd/repository/MyCdRepository.java
+++ b/roome/src/main/java/com/roome/domain/mycd/repository/MyCdRepository.java
@@ -14,8 +14,6 @@ public interface MyCdRepository extends JpaRepository<MyCd, Long> {
 
   boolean existsById(Long id);
 
-  boolean existsByUserIdAndCdId(Long userId, Long cdId);
-
   List<MyCd> findByUserId(Long userId);
 
   Optional<MyCd> findByIdAndUserId(Long myCdId, Long userId);
@@ -38,12 +36,6 @@ public interface MyCdRepository extends JpaRepository<MyCd, Long> {
       + "OR LOWER(c.artist) LIKE LOWER(CONCAT('%', :keyword, '%'))) " + "ORDER BY mc.id ASC")
   Page<MyCd> searchByUserIdAndKeyword(@Param("userId") Long userId,
       @Param("keyword") String keyword, Pageable pageable);
-
-  // 검색된 결과의 전체 개수 반환
-  @Query("SELECT COUNT(mc) FROM MyCd mc JOIN mc.cd c " + "WHERE mc.user.id = :userId "
-      + "AND (LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) "
-      + "OR LOWER(c.artist) LIKE LOWER(CONCAT('%', :keyword, '%')))")
-  long countByUserIdAndKeyword(@Param("userId") Long userId, @Param("keyword") String keyword);
 
   @Modifying
   @Query("DELETE FROM MyCd mc WHERE mc.user.id = :userId AND mc.id IN (:ids)")

--- a/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
+++ b/roome/src/main/java/com/roome/domain/mycd/service/MyCdService.java
@@ -117,11 +117,13 @@ public class MyCdService {
 
     try {
       if (isKeywordSearch) {
-        myCdsPage = myCdRepository.searchByUserIdAndKeyword(userId, keyword, pageable);
+        myCdsPage = myCdRepository.searchMyCd(userId, keyword, cursor, size);
       } else {
         myCdsPage = (cursor == null || cursor == 0)
-            ? myCdRepository.findByUserIdOrderByIdAsc(userId, pageable) // 첫 페이지
-            : myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor, pageable);
+            ? myCdRepository.findByUserIdOrderByIdAsc(userId,
+            PageRequest.of(0, size, Sort.by(Sort.Direction.ASC, "id")))
+            : myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor,
+                PageRequest.of(0, size, Sort.by(Sort.Direction.ASC, "id")));
       }
     } catch (Exception e) {
       throw new MyCdDatabaseException("CD 목록을 불러오는 중 오류가 발생했습니다.");

--- a/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/controller/MyCdControllerTest.java
@@ -1,135 +1,152 @@
-//package com.roome.domain.mycd.controller;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.roome.domain.mycd.dto.MyCdCreateRequest;
-//import com.roome.domain.mycd.dto.MyCdListResponse;
-//import com.roome.domain.mycd.dto.MyCdResponse;
-//import com.roome.domain.mycd.service.MyCdService;
-//import java.time.LocalDate;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.BDDMockito;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.http.MediaType;
-//import org.springframework.security.test.context.support.WithMockUser;
-//import org.springframework.test.web.servlet.MockMvc;
-//
-//import java.util.List;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-//
-//@WebMvcTest(MyCdController.class)
-//class MyCdControllerTest {
-//
-//  @Autowired
-//  private MockMvc mockMvc;
-//
-//  @MockBean
-//  private MyCdService myCdService;
-//
-//  @Autowired
-//  private ObjectMapper objectMapper;
-//
-//  @DisplayName("CD 추가 성공")
-//  @WithMockUser(username = "1")
-//  @Test
-//  void addMyCd_Success() throws Exception {
-//    MyCdCreateRequest request = createMyCdCreateRequest();
-//    MyCdResponse response = createMyCdResponse(1L, request);
-//
-//    BDDMockito.given(myCdService.addCdToMyList(eq(1L), any(MyCdCreateRequest.class)))
-//        .willReturn(response);
-//
-//    mockMvc.perform(post("/api/my-cd")
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .content(objectMapper.writeValueAsString(request))
-//            .with(csrf()))
-//        .andExpect(status().isCreated())
-//        .andExpect(jsonPath("$.title").value("Palette"))
-//        .andExpect(jsonPath("$.artist").value("IU"));
-//
-//    BDDMockito.verify(myCdService).addCdToMyList(eq(1L), any(MyCdCreateRequest.class));
-//  }
-//
-//  @DisplayName("내 CD 목록 조회 성공 - 키워드 X, 커서 X")
-//  @WithMockUser(username = "1")
-//  @Test
-//  void getMyCdList_Success_NoKeywordNoCursor() throws Exception {
-//    MyCdListResponse response = new MyCdListResponse(
-//        List.of(createMyCdResponse(1L, createMyCdCreateRequest())), 1L, 100L);
-//
-//    BDDMockito.given(myCdService.getMyCdList(eq(1L), any(String.class), any(Long.class), any(Integer.class)))
-//        .willReturn(response);
-//
-//    mockMvc.perform(get("/api/my-cd").param("size", "10").accept(MediaType.APPLICATION_JSON))
-//        .andExpect(status().isOk());
-//
-//    BDDMockito.verify(myCdService).getMyCdList(eq(1L), eq(null), eq(null), eq(10));
-//  }
-//
-//  @DisplayName("내 CD 목록 조회 성공 - 키워드 포함")
-//  @WithMockUser(username = "1")
-//  @Test
-//  void getMyCdList_Success_WithKeyword() throws Exception {
-//    MyCdListResponse response = new MyCdListResponse(
-//        List.of(createMyCdResponse(1L, createMyCdCreateRequest())), 1L, 100L);
-//
-//    BDDMockito.given(myCdService.getMyCdList(eq(1L), eq("IU"), any(Long.class), any(Integer.class)))
-//        .willReturn(response);
-//
-//    mockMvc.perform(get("/api/my-cd")
-//            .param("size", "10")
-//            .param("keyword", "IU")
-//            .accept(MediaType.APPLICATION_JSON))
-//        .andExpect(status().isOk());
-//
-//    BDDMockito.verify(myCdService).getMyCdList(eq(1L), eq("IU"), eq(null), eq(10));
-//  }
-//
-//  @DisplayName("특정 CD 조회 성공")
-//  @WithMockUser(username = "1")
-//  @Test
-//  void getMyCd_Success() throws Exception {
-//    MyCdResponse response = createMyCdResponse(1L, createMyCdCreateRequest());
-//
-//    BDDMockito.given(myCdService.getMyCd(eq(1L), eq(1L))).willReturn(response);
-//
-//    mockMvc.perform(get("/api/my-cd/1"))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.title").value("Palette"));
-//
-//    BDDMockito.verify(myCdService).getMyCd(eq(1L), eq(1L));
-//  }
-//
-//  @DisplayName("CD 삭제 성공")
-//  @WithMockUser(username = "1")
-//  @Test
-//  void deleteMyCd_Success() throws Exception {
-//    mockMvc.perform(delete("/api/my-cd")
-//            .param("myCdIds", "1")
-//            .param("myCdIds", "2")
-//            .param("myCdIds", "3")
-//            .with(csrf()))
-//        .andExpect(status().isNoContent());
-//
-//    BDDMockito.verify(myCdService).delete(eq(1L), eq(List.of(1L, 2L, 3L)));
-//  }
-//
-//  private MyCdCreateRequest createMyCdCreateRequest() {
-//    return new MyCdCreateRequest("Palette", "IU", "Palette", LocalDate.of(2019, 11, 1),
-//        List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
-//        "https://youtube.com/watch?v=asdf5678", 215);
-//  }
-//
-//  private MyCdResponse createMyCdResponse(Long myCdId, MyCdCreateRequest request) {
-//    return new MyCdResponse(myCdId, request.getTitle(), request.getArtist(), request.getAlbum(),
-//        request.getReleaseDate(), request.getGenres(), request.getCoverUrl(),
-//        request.getYoutubeUrl(), request.getDuration());
-//  }
-//}
+package com.roome.domain.mycd.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roome.domain.mycd.dto.MyCdCreateRequest;
+import com.roome.domain.mycd.dto.MyCdListResponse;
+import com.roome.domain.mycd.dto.MyCdResponse;
+import com.roome.domain.mycd.service.MyCdService;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MyCdController.class)
+class MyCdControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private MyCdService myCdService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @DisplayName("CD 추가 성공")
+  @WithMockUser(username = "1")
+  @Test
+  void addMyCd_Success() throws Exception {
+    MyCdCreateRequest request = createMyCdCreateRequest();
+    MyCdResponse response = createMyCdResponse(1L, request);
+
+    BDDMockito.given(myCdService.addCdToMyList(eq(1L), any(MyCdCreateRequest.class)))
+        .willReturn(response);
+
+    mockMvc.perform(post("/api/my-cd")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .with(csrf()))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.title").value("Palette"))
+        .andExpect(jsonPath("$.artist").value("IU"));
+
+    BDDMockito.verify(myCdService).addCdToMyList(eq(1L), any(MyCdCreateRequest.class));
+  }
+
+  @Test
+  @DisplayName("내 CD 목록 조회 성공 - targetUserId 없음 (자기 자신의 목록 조회)")
+  @WithMockUser(username = "1")
+  void getMyCdList_Success_NoTargetUserId() throws Exception {
+    MyCdListResponse response = new MyCdListResponse(
+        List.of(createMyCdResponse(1L, createMyCdCreateRequest())),
+        1L, // nextCursor
+        100L, // totalCount
+        1L, // firstMyCdId
+        10L  // lastMyCdId
+    );
+
+    // targetUserId가 없는 경우
+    BDDMockito.given(myCdService.getMyCdList(eq(1L), any(String.class), any(Long.class), any(Integer.class)))
+        .willReturn(response);
+
+    mockMvc.perform(get("/api/my-cd")
+            .param("size", "10")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // targetUserId가 없을 경우 userId가 최종적으로 사용되는지 확인
+    BDDMockito.verify(myCdService).getMyCdList(eq(1L), eq(null), eq(null), eq(10));
+  }
+
+  @Test
+  @DisplayName("다른 사용자의 CD 목록 조회 성공 - targetUserId 있음")
+  @WithMockUser(username = "1")
+  void getMyCdList_Success_WithTargetUserId() throws Exception {
+    MyCdListResponse response = new MyCdListResponse(
+        List.of(createMyCdResponse(1L, createMyCdCreateRequest())),
+        2L, // nextCursor
+        200L, // totalCount
+        5L, // firstMyCdId
+        15L  // lastMyCdId
+    );
+
+    // targetUserId가 있는 경우
+    BDDMockito.given(myCdService.getMyCdList(eq(2L), any(String.class), any(Long.class), any(Integer.class)))
+        .willReturn(response);
+
+    mockMvc.perform(get("/api/my-cd")
+            .param("targetUserId", "2")  // 다른 사용자 조회
+            .param("size", "10")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // targetUserId가 있으면 그것이 사용되는지 확인
+    BDDMockito.verify(myCdService).getMyCdList(eq(2L), eq(null), eq(null), eq(10));
+  }
+
+  @DisplayName("특정 CD 조회 성공")
+  @WithMockUser(username = "1")
+  @Test
+  void getMyCd_Success() throws Exception {
+    MyCdResponse response = createMyCdResponse(1L, createMyCdCreateRequest());
+
+    BDDMockito.given(myCdService.getMyCd(eq(1L), eq(1L))).willReturn(response);
+
+    mockMvc.perform(get("/api/my-cd/1")
+            .param("targetUserId", "1")) // 필수값 추가
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("Palette"));
+
+    BDDMockito.verify(myCdService).getMyCd(eq(1L), eq(1L));
+  }
+
+  @DisplayName("CD 삭제 성공")
+  @WithMockUser(username = "1")
+  @Test
+  void deleteMyCd_Success() throws Exception {
+    mockMvc.perform(delete("/api/my-cd")
+            .param("myCdIds", "1")
+            .param("myCdIds", "2")
+            .param("myCdIds", "3")
+            .with(csrf()))  // CSRF 적용
+        .andExpect(status().isNoContent());
+
+    BDDMockito.verify(myCdService).delete(eq(1L), eq(List.of(1L, 2L, 3L)));
+  }
+
+  private MyCdCreateRequest createMyCdCreateRequest() {
+    return new MyCdCreateRequest("Palette", "IU", "Palette", LocalDate.of(2019, 11, 1),
+        List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
+        "https://youtube.com/watch?v=asdf5678", 215);
+  }
+
+  private MyCdResponse createMyCdResponse(Long myCdId, MyCdCreateRequest request) {
+    return new MyCdResponse(myCdId, request.getTitle(), request.getArtist(), request.getAlbum(),
+        request.getReleaseDate(), request.getGenres(), request.getCoverUrl(),
+        request.getYoutubeUrl(), request.getDuration());
+  }
+}

--- a/roome/src/test/java/com/roome/domain/mycd/service/MyCdServiceTest.java
+++ b/roome/src/test/java/com/roome/domain/mycd/service/MyCdServiceTest.java
@@ -1,19 +1,24 @@
-/*
 package com.roome.domain.mycd.service;
 
 import com.roome.domain.cd.entity.Cd;
 import com.roome.domain.cd.repository.CdGenreTypeRepository;
 import com.roome.domain.cd.repository.CdRepository;
+import com.roome.domain.furniture.entity.Furniture;
+import com.roome.domain.furniture.entity.FurnitureCapacity;
+import com.roome.domain.furniture.entity.FurnitureType;
+import com.roome.domain.furniture.repository.FurnitureRepository;
+import com.roome.domain.furniture.service.FurnitureService;
 import com.roome.domain.mycd.dto.MyCdCreateRequest;
 import com.roome.domain.mycd.dto.MyCdListResponse;
 import com.roome.domain.mycd.dto.MyCdResponse;
 import com.roome.domain.mycd.entity.MyCd;
 import com.roome.domain.mycd.entity.MyCdCount;
-import com.roome.domain.mycd.exception.MyCdAlreadyExistsException;
 import com.roome.domain.mycd.exception.MyCdListEmptyException;
 import com.roome.domain.mycd.exception.MyCdNotFoundException;
 import com.roome.domain.mycd.repository.MyCdCountRepository;
 import com.roome.domain.mycd.repository.MyCdRepository;
+import com.roome.domain.rank.entity.ActivityType;
+import com.roome.domain.rank.service.UserActivityService;
 import com.roome.domain.room.entity.Room;
 import com.roome.domain.room.repository.RoomRepository;
 import com.roome.domain.user.entity.User;
@@ -22,312 +27,224 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class MyCdServiceTest {
 
+  @Mock
   private MyCdRepository myCdRepository;
+  @Mock
   private CdRepository cdRepository;
-  private MyCdCountRepository myCdCountRepository;
+  @Mock
   private RoomRepository roomRepository;
+  @Mock
   private UserRepository userRepository;
+  @Mock
+  private FurnitureRepository furnitureRepository;
+  @Mock
+  private FurnitureCapacity furnitureCapacity;
+  @Mock
+  private FurnitureType furnitureType;
+  @Mock
   private CdGenreTypeRepository cdGenreTypeRepository;
+  @Mock
+  private MyCdCountRepository myCdCountRepository;
+  @Mock
+  private FurnitureService furnitureService;
+  @Mock
+  private UserActivityService userActivityService;
+  @Mock
+  private Room room;
+  @Mock
+  private Furniture furniture;
+
+  @InjectMocks
   private MyCdService myCdService;
+
+  private User user;
+  private Cd cd;
+  private MyCd myCd;
 
   @BeforeEach
   void setUp() {
-    myCdRepository = mock(MyCdRepository.class);
-    cdRepository = mock(CdRepository.class);
-    myCdCountRepository = mock(MyCdCountRepository.class);
-    roomRepository = mock(RoomRepository.class);
-    userRepository = mock(UserRepository.class);
-    cdGenreTypeRepository = mock(CdGenreTypeRepository.class);
-    myCdService = new MyCdService(myCdRepository, cdRepository, myCdCountRepository, roomRepository,
-        userRepository, cdGenreTypeRepository);
+    user = User.builder().id(1L).nickname("테스트 유저").build();
+    room = Room.builder().id(1L).user(user).build();
+    cd = Cd.builder().id(1L).title("Palette").artist("IU").build();
+    myCd = MyCd.builder().id(1L).user(user).room(room).cd(cd).build();
   }
 
-  @Test
-  @DisplayName("새로운 CD 추가 성공")
-  void addCdToMyList_Success_NewCd() {
-    Long userId = 1L;
-    MyCdCreateRequest request = new MyCdCreateRequest(
-        "New Album", "New Artist", "New Album",
-        LocalDate.of(2022, 1, 1),
-        List.of("Pop"), "https://example.com/new_cd.jpg",
-        "https://youtube.com/watch?v=newvideo", 200
-    );
-
-    User user = mock(User.class);
-    Room room = mock(Room.class);
-    Cd newCd = mock(Cd.class);
-    MyCd myCd = mock(MyCd.class);
-    MyCdCount myCdCount = mock(MyCdCount.class);
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(roomRepository.findByUserId(userId)).thenReturn(Optional.of(room));
-    when(cdRepository.findByTitleAndArtist(request.getTitle(), request.getArtist()))
-        .thenReturn(Optional.empty());
-    when(cdRepository.save(any(Cd.class))).thenReturn(newCd);
-    when(myCdRepository.save(any(MyCd.class))).thenReturn(myCd);
-    when(myCdCountRepository.findByRoom(room)).thenReturn(Optional.of(myCdCount));
-
-    when(myCd.getCd()).thenReturn(newCd);
-    when(newCd.getTitle()).thenReturn("New Album");
-    when(newCd.getArtist()).thenReturn("New Artist");
-
-    MyCdResponse response = myCdService.addCdToMyList(userId, request);
-
-    assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("New Album");
-    assertThat(response.getArtist()).isEqualTo("New Artist");
-
-    verify(cdRepository, times(1)).save(any(Cd.class));
-  }
-
-  @Test
-  @DisplayName("CD 추가 실패 - 중복된 CD")
-  void addCdToMyList_Failure_AlreadyExists() {
-    Long userId = 1L;
-    MyCdCreateRequest request = new MyCdCreateRequest("Palette", "IU", "Palette",
-        LocalDate.of(2019, 11, 1),
-        List.of("K-Pop", "Ballad"), "https://example.com/image1.jpg",
-        "https://youtube.com/watch?v=asdf5678", 215);
-
-    Cd cd = mock(Cd.class);
-    User user = mock(User.class);
-    Room room = mock(Room.class);
-    MyCd myCd = mock(MyCd.class);
-    MyCdCount myCdCount = mock(MyCdCount.class);
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(roomRepository.findByUserId(userId)).thenReturn(Optional.of(room));
-    when(cdRepository.findByTitleAndArtist(request.getTitle(), request.getArtist()))
-        .thenReturn(Optional.of(cd));
-    when(myCdRepository.existsByUserIdAndCdId(userId, 1L)).thenReturn(true);
-    when(myCdCountRepository.findByRoom(room)).thenReturn(Optional.of(myCdCount));
-
-    when(myCdRepository.save(any(MyCd.class))).thenReturn(myCd);
-
-    when(myCd.getCd()).thenReturn(cd);
-    when(cd.getId()).thenReturn(1L);
-
-    assertThatThrownBy(() -> myCdService.addCdToMyList(userId, request))
-        .isInstanceOf(MyCdAlreadyExistsException.class);
-  }
+//  @Test
+//  @DisplayName("CD 추가 성공 - CD 랙 레벨 확인 및 저장")
+//  void addCdToMyList_Success() {
+//    // Given
+//    MyCdCreateRequest request = new MyCdCreateRequest(
+//        "Palette", "IU", "Palette",
+//        LocalDate.of(2019, 11, 1),
+//        List.of("K-Pop", "Ballad"),
+//        "https://example.com/image1.jpg",
+//        "https://youtube.com/watch?v=asdf5678",
+//        215
+//    );
+//
+//    when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+//    when(roomRepository.findByUserId(1L)).thenReturn(Optional.of(room));
+//
+//    // 가구 서비스 Mock 설정
+//    Furniture furnitureMock = mock(Furniture.class); // Mock 객체 생성
+//    when(furnitureMock.getLevel()).thenReturn(2); // `getLevel()`을 Mocking
+//    when(furnitureRepository.findByRoomAndFurnitureType(any(Room.class), eq(FurnitureType.CD_RACK)))
+//        .thenReturn(Optional.of(furnitureMock)); // Mock 객체 반환 보장
+//
+//    when(furnitureCapacity.getMaxCdCapacity(2)).thenReturn(50); // 최대 수용량 Mock
+//
+//    // 현재 등록된 CD 개수 (현재 10개로 설정)
+//    when(myCdRepository.countByUserId(1L)).thenReturn(10L);
+//
+//    // CD 존재 여부 Mock 설정 (새로 생성해야 하는 경우)
+//    when(cdRepository.findByTitleAndArtist(request.getTitle(), request.getArtist()))
+//        .thenReturn(Optional.empty());
+//
+//    Cd newCd = mock(Cd.class);
+//    when(newCd.getId()).thenReturn(99L); // 새 CD ID
+//    when(cdRepository.save(any(Cd.class))).thenReturn(newCd);
+//
+//    // 중복 추가 방지 Mock 설정 (중복이 없도록 설정)
+//    when(myCdRepository.findByUserIdAndCdId(1L, newCd.getId())).thenReturn(Optional.empty());
+//
+//    // MyCd 저장 Mock 설정
+//    MyCd myCd = mock(MyCd.class);
+//    when(myCd.getCd()).thenReturn(newCd);
+//    when(myCdRepository.save(any(MyCd.class))).thenReturn(myCd);
+//
+//    // MyCdCount Mock 설정
+//    MyCdCount myCdCount = mock(MyCdCount.class);
+//    when(myCdCountRepository.findByRoom(room)).thenReturn(Optional.of(myCdCount));
+//    doNothing().when(myCdCount).increment();
+//
+//    // 유저 활동 기록 Mock 설정
+//    doNothing().when(userActivityService).recordUserActivity(1L, ActivityType.MUSIC_REGISTRATION, newCd.getId());
+//
+//    // When
+//    MyCdResponse response = myCdService.addCdToMyList(1L, request);
+//
+//    // Then
+//    assertThat(response).isNotNull();
+//    assertThat(response.getTitle()).isEqualTo("Palette");
+//    assertThat(response.getArtist()).isEqualTo("IU");
+//
+//    // 저장 메서드들이 제대로 호출되었는지 검증
+//    verify(cdRepository, times(1)).save(any(Cd.class));
+//    verify(myCdRepository, times(1)).save(any(MyCd.class));
+//    verify(myCdCount, times(1)).increment();
+//    verify(userActivityService, times(1)).recordUserActivity(1L, ActivityType.MUSIC_REGISTRATION, newCd.getId());
+//  }
 
   @Test
-  @DisplayName("내 CD 목록 조회 - 커서 기반 페이징 성공")
-  void getMyCdList_WithCursor_Success() {
-    Long userId = 1L;
-    Long cursor = 5L;
+  @DisplayName("내 CD 목록 조회 성공 - 키워드 없음, 커서 없음")
+  @WithMockUser(username = "1")
+  void getMyCdList_Success_NoKeywordNoCursor() throws Exception {
     PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
 
-    User user = mock(User.class);
-    Cd cd = mock(Cd.class);
-    MyCd myCd = mock(MyCd.class);
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-    when(myCdRepository.findByUserIdOrderByIdAsc(userId, pageRequest))
+    when(myCdRepository.findByUserIdOrderByIdAsc(eq(1L), any(PageRequest.class)))
         .thenReturn(new PageImpl<>(List.of(myCd), pageRequest, 1));
 
-    when(myCdRepository.findByUserIdAndIdGreaterThanOrderByIdAsc(userId, cursor, pageRequest))
-        .thenReturn(new PageImpl<>(List.of(myCd), pageRequest, 1));
+    // 첫 번째 & 마지막 CD ID 조회 Mock 추가
+    when(myCdRepository.findFirstByUserIdOrderByIdAsc(1L)).thenReturn(Optional.of(myCd));
+    when(myCdRepository.findFirstByUserIdOrderByIdDesc(1L)).thenReturn(Optional.of(myCd));
 
-    when(myCd.getCd()).thenReturn(cd);
-    when(myCd.getId()).thenReturn(1L);
-    when(cd.getId()).thenReturn(1L);
-    when(cd.getTitle()).thenReturn("Palette");
-    when(cd.getArtist()).thenReturn("IU");
-
-    MyCdListResponse response = myCdService.getMyCdList(userId, null, cursor, 10);
+    MyCdListResponse response = myCdService.getMyCdList(1L, null, null, 10);
 
     assertThat(response).isNotNull();
     assertThat(response.getData()).hasSize(1);
   }
 
-
   @Test
-  @DisplayName("내 CD 목록 조회 - 키워드 검색 성공")
-  void getMyCdList_WithKeyword_Success() {
-    Long userId = 1L;
-    String keyword = "IU";
+  @DisplayName("내 CD 목록 조회 성공 - 키워드 검색 포함")
+  @WithMockUser(username = "1")
+  void getMyCdList_Success_WithKeyword() throws Exception {
     PageRequest pageRequest = PageRequest.of(0, 10);
 
-    User user = mock(User.class);
-    Cd cd = mock(Cd.class);
-    MyCd myCd = mock(MyCd.class);
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-    when(myCdRepository.searchByUserIdAndKeyword(eq(userId), eq(keyword), any(PageRequest.class)))
+    when(myCdRepository.searchByUserIdAndKeyword(eq(1L), eq("IU"), any(PageRequest.class)))
         .thenReturn(new PageImpl<>(List.of(myCd), pageRequest, 1));
 
-    when(myCdRepository.countByUserIdAndKeyword(eq(userId), eq(keyword)))
-        .thenReturn(1L);
+    // 첫 번째 & 마지막 CD ID 조회 Mock 추가
+    when(myCdRepository.findFirstByUserIdOrderByIdAsc(1L)).thenReturn(Optional.of(myCd));
+    when(myCdRepository.findFirstByUserIdOrderByIdDesc(1L)).thenReturn(Optional.of(myCd));
 
-    when(myCd.getCd()).thenReturn(cd);
-    when(myCd.getId()).thenReturn(1L);
-    when(cd.getId()).thenReturn(1L);
-    when(cd.getTitle()).thenReturn("Palette");
-    when(cd.getArtist()).thenReturn("IU");
-
-    MyCdListResponse response = myCdService.getMyCdList(userId, keyword, null, 10);
+    MyCdListResponse response = myCdService.getMyCdList(1L, "IU", null, 10);
 
     assertThat(response).isNotNull();
     assertThat(response.getData()).hasSize(1);
   }
 
   @Test
-  @DisplayName("내 CD 목록 조회 - cursor가 0일 때 성공")
-  void getMyCdList_WithZeroCursor_Success() {
-    Long userId = 1L;
-    Long cursor = 0L;
-    PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
-    MyCd myCd = mock(MyCd.class);
-    Cd cd = mock(Cd.class);
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
-
-    when(myCdRepository.findByUserIdOrderByIdAsc(userId, pageRequest))
-        .thenReturn(new PageImpl<>(List.of(myCd), pageRequest, 1));
-
-    when(myCd.getCd()).thenReturn(cd);
-    when(myCd.getId()).thenReturn(1L);
-    when(cd.getId()).thenReturn(1L);
-    when(cd.getTitle()).thenReturn("Palette");
-    when(cd.getArtist()).thenReturn("IU");
-
-    MyCdListResponse response = myCdService.getMyCdList(userId, null, cursor, 10);
-
-    assertThat(response).isNotNull();
-    assertThat(response.getData()).hasSize(1);
-  }
-
-  @Test
-  @DisplayName("내 CD 목록 조회 - 키워드 검색 실패 (결과 없음)")
-  void getMyCdList_WithKeyword_Failure() {
-    Long userId = 1L;
-    String keyword = "Unknown Artist";
-    PageRequest pageRequest = PageRequest.of(0, 10); // 추가된 부분
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
-
-    when(myCdRepository.searchByUserIdAndKeyword(eq(userId), eq(keyword), any(PageRequest.class)))
-        .thenReturn(new PageImpl<>(List.of(), pageRequest, 0)); // 빈 리스트 반환
-
-    when(myCdRepository.countByUserIdAndKeyword(eq(userId), eq(keyword))).thenReturn(0L);
-
-    assertThatThrownBy(() -> myCdService.getMyCdList(userId, keyword, null, 10))
-        .isInstanceOf(MyCdListEmptyException.class);
-  }
-
-  @Test
-  @DisplayName("내 CD 목록 조회 실패 - 보유한 CD 없음")
+  @DisplayName("내 CD 목록 조회 실패 - 결과 없음")
   void getMyCdList_Failure_Empty() {
-    Long userId = 1L;
     PageRequest pageRequest = PageRequest.of(0, 10);
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
-    when(myCdRepository.findByUserIdOrderByIdAsc(userId, pageRequest))
+    when(myCdRepository.findByUserIdOrderByIdAsc(eq(1L), any(PageRequest.class)))
         .thenReturn(new PageImpl<>(List.of(), pageRequest, 0));
 
-    assertThatThrownBy(() -> myCdService.getMyCdList(userId, null, null, 10))
+    assertThatThrownBy(() -> myCdService.getMyCdList(1L, null, null, 10))
         .isInstanceOf(MyCdListEmptyException.class);
   }
 
-
   @Test
-  @DisplayName("내 CD 목록 조회 - cursor 없음")
-  void getMyCdList_Success_NoCursor() {
-    Long userId = 1L;
-    PageRequest pageRequest = PageRequest.of(0, 10);
-    MyCd myCd = mock(MyCd.class);
-    Cd cd = mock(Cd.class);
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
-    when(myCdRepository.findByUserIdOrderByIdAsc(userId, pageRequest))
-        .thenReturn(new PageImpl<>(List.of(myCd), pageRequest, 1));
-
-    when(myCd.getCd()).thenReturn(cd);
-    when(myCd.getId()).thenReturn(1L);
-
-    assertThatThrownBy(() -> myCdService.getMyCdList(userId, null, null, 10))
-        .isInstanceOf(MyCdListEmptyException.class);
-
-  }
-
-  @Test
-  @DisplayName("CD 단건 조회 - 존재하는 CD 조회 성공")
+  @DisplayName("CD 단건 조회 성공")
   void getMyCd_Success() {
-    Long userId = 1L;
-    Long myCdId = 1L;
+    when(myCdRepository.findByIdAndUserId(eq(1L), eq(1L)))
+        .thenReturn(Optional.of(myCd));
 
-    User user = mock(User.class);
-    Cd cd = mock(Cd.class);
-    MyCd myCd = mock(MyCd.class);
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    when(myCdRepository.findByIdAndUserId(myCdId, userId)).thenReturn(Optional.of(myCd));
-
-    when(myCd.getCd()).thenReturn(cd);
-    when(myCd.getId()).thenReturn(1L);
-    when(cd.getId()).thenReturn(1L);
-    when(cd.getTitle()).thenReturn("Palette");
-    when(cd.getArtist()).thenReturn("IU");
-
-    MyCdResponse response = myCdService.getMyCd(userId, myCdId);
+    MyCdResponse response = myCdService.getMyCd(1L, 1L);
 
     assertThat(response).isNotNull();
     assertThat(response.getTitle()).isEqualTo("Palette");
   }
 
-
   @Test
   @DisplayName("CD 단건 조회 실패 - 존재하지 않음")
   void getMyCd_Failure_NotFound() {
-    Long userId = 1L;
-    Long myCdId = 999L;
-    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
-    when(myCdRepository.findByIdAndUserId(myCdId, userId)).thenReturn(Optional.empty());
+    when(myCdRepository.findByIdAndUserId(eq(999L), eq(1L)))
+        .thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> myCdService.getMyCd(userId, myCdId))
+    assertThatThrownBy(() -> myCdService.getMyCd(1L, 999L))
         .isInstanceOf(MyCdNotFoundException.class);
   }
 
   @Test
   @DisplayName("CD 삭제 성공")
   void delete_Success() {
-    Long userId = 1L;
     List<Long> ids = List.of(1L, 2L, 3L);
+    when(myCdRepository.findAllById(ids)).thenReturn(List.of(myCd, myCd));
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
-    when(myCdRepository.findAllById(ids)).thenReturn(List.of(mock(MyCd.class), mock(MyCd.class)));
+    myCdService.delete(1L, ids);
 
-    myCdService.delete(userId, ids);
-
-    verify(myCdRepository, times(1)).deleteByUserIdAndIds(userId, ids);
+    verify(myCdRepository, times(1)).deleteByUserIdAndIds(1L, ids);
   }
 
   @Test
   @DisplayName("CD 삭제 실패 - 존재하지 않음")
   void delete_Failure_NotFound() {
-    Long userId = 1L;
     List<Long> ids = List.of(1L, 2L, 3L);
-
-    when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
     when(myCdRepository.findAllById(ids)).thenReturn(List.of());
 
-    assertThatThrownBy(() -> myCdService.delete(userId, ids))
+    assertThatThrownBy(() -> myCdService.delete(1L, ids))
         .isInstanceOf(MyCdNotFoundException.class);
   }
-}*/
+}


### PR DESCRIPTION
## 📌 PR 제목 Feat: QueryDSL 기반 검색 기능 추가 및 성능 최적화

### ✅ PR 설명
QueryDSL을 활용하여 MyCd 검색 기능을 최적화하고 기존 JPA 메서드를 개선하였습니다.
이전 대비 성능을 향상시키고, 키워드 검색 기능을 확장하였습니다.

### 🏗 작업 내용
 - [ ] MyCdQueryRepository, MyCdQueryRepositoryImpl 생성 및 QueryDSL 적용
 - [ ] 기존 MyCdRepository.findByUserIdAndKeyword → QueryDSL 기반으로 변경
 - [ ] MyCdService.getMyCdList()에 QueryDSL 검색 로직 적용
 - [ ] 검색 최적화를 위한 MySQL/MariaDB 인덱스 추가 (title, artist 필드)

### 📸 테스트 결과 (선택)
> 
QueryDSL 적용 전후 성능 비교 (k6 테스트 결과)
<img width="1484" alt="스크린샷 2025-03-07 03 12 35" src="https://github.com/user-attachments/assets/8625cf26-4906-4637-ae69-22ed7732d8d8" />
- 평균 응답 시간 (http_req_duration)
  - Before: 356.49ms
  - After: 91.7ms (~74% 감소)

- P95 응답 속도
  - Before: 644.81ms
  - After: 23.73ms

- 처리량 (http_reqs/s)
  - Before: 162 req/s
  - After: 214 req/s (+21.6% 증가)

### 🔗 관련 이슈 (선택)
> #338 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
