### PR TITLE
Fix: ForbiddenException 발생 시 500 → 403으로 반환되도록 예외 처리 추가

### DIFF
--- a/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
+++ b/roome/src/main/java/com/roome/global/exception/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ import org.springframework.web.context.request.WebRequest;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-  // 비즈니스 관련 예러 처리
+  // 비즈니스 관련 예외 처리
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<ErrorResponse> handleCustomException(BusinessException e) {
     ErrorCode error = e.getErrorCode();
@@ -30,6 +30,14 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(error.getStatus())
         .body(new ErrorResponse(error.getMessage(), error.getStatus().value()));
+  }
+
+  // ForbiddenException 처리 추가 (403 반환)
+  @ExceptionHandler(ForbiddenException.class)
+  public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+    return ResponseEntity
+        .status(HttpStatus.FORBIDDEN)
+        .body(new ErrorResponse(e.getMessage(), HttpStatus.FORBIDDEN.value()));
   }
 
   // DB 관련 예외 처리
@@ -47,7 +55,7 @@ public class GlobalExceptionHandler {
     return new MessageResponse("인증 토큰이 필요합니다.");
   }
 
-  // 그 외 모든 예외를 처리하는 핸들러 추가
+  // 기타 모든 예외는 500으로 처리 (ForbiddenException보다 아래에 있어야 함)
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleAllExceptions(Exception e, WebRequest request) {
     log.error("처리되지 않은 예외 발생: {}", e.getMessage(), e);


### PR DESCRIPTION
## 📌 Fix: ForbiddenException 발생 시 500 → 403으로 반환되도록 예외 처리 추가

### ✅ PR 설명
해당 PR에서 수행한 작업을 간단히 설명해주세요.

### 🏗 작업 내용
- GlobalExceptionHandler에 ForbiddenException 핸들러 추가
- 500으로 처리되던 ForbiddenException을 명확히 403으로 반환하도록 수정
- MockMvc 테스트에서 예상 응답 코드(403)와 실제 응답 코드(500) 불일치 문제 해결
### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> #359 

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
