### PR TITLE
Fix: 환불해도 paymentKey는 똑같도록 수정 및 하우스메이트라고 뜨는 조건 변경

### DIFF
--- a/roome/src/main/java/com/roome/domain/guestbook/service/GuestbookService.java
+++ b/roome/src/main/java/com/roome/domain/guestbook/service/GuestbookService.java
@@ -65,7 +65,7 @@ public class GuestbookService {
     Map<Long, Boolean> housemateStatusMap = userIds.stream()
         .collect(Collectors.toMap(
             userId -> userId,
-            userId -> housemateRepository.existsByUserIdAndAddedId(userId, roomOwnerId)
+            userId -> housemateRepository.existsByUserIdAndAddedId(roomOwnerId, userId)
         ));
 
     List<GuestbookResponseDto> guestbooks = guestbookPage.stream()
@@ -97,7 +97,7 @@ public class GuestbookService {
     Long roomOwnerId = room.getUser().getId();
     boolean isSelfRoom = userId.equals(roomOwnerId); // 본인 방인지 확인
 
-    boolean isHousemate = housemateRepository.existsByUserIdAndAddedId(userId, roomOwnerId);
+    boolean isHousemate = housemateRepository.existsByUserIdAndAddedId(roomOwnerId, userId);
 
     Guestbook guestbook = Guestbook.builder()
         .room(room)

--- a/roome/src/main/java/com/roome/domain/payment/service/PaymentService.java
+++ b/roome/src/main/java/com/roome/domain/payment/service/PaymentService.java
@@ -290,7 +290,7 @@ public class PaymentService {
             .user(payment.getUser())
             .amount(-refundAmount)
             .earnedPoints(-payment.getPurchasedPoints())
-            .paymentKey(paymentKey + "-REFUND")
+            .paymentKey(paymentKey)
             .isRefund(true) // 환불 내역임을 표시
             .build();
     paymentLogRepository.save(refundLog);


### PR DESCRIPTION
## 📌 PR 제목 (예: `feat: 회원가입 기능 추가`)

### ✅ PR 설명
환불해도 paymentKey는 똑같도록 수정 및 하우스메이트라고 뜨는 조건 변경

### 🏗 작업 내용
- [ ] 환불해도 paymentKey는 똑같도록 수정
- [ ] 하우스메이트라고 뜨는 조건 변경

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
