### PR TITLE
Fix: 회원 탈퇴 시 외래 키 제약 조건 문제 해결

### DIFF
--- a/roome/src/main/java/com/roome/domain/payment/repository/PaymentLogRepository.java
+++ b/roome/src/main/java/com/roome/domain/payment/repository/PaymentLogRepository.java
@@ -2,19 +2,21 @@ package com.roome.domain.payment.repository;
 
 import com.roome.domain.payment.entity.PaymentLog;
 import com.roome.domain.user.entity.User;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface PaymentLogRepository extends JpaRepository<PaymentLog, Long> {
 
-    // 특정 사용자(userId)의 결제 기록 조회
-    List<PaymentLog> findByUserId(Long userId);
+  // 특정 사용자(userId)의 결제 기록 조회
+  List<PaymentLog> findByUserId(Long userId);
 
-    Page<PaymentLog> findByUser(User user, Pageable pageable);
+  Page<PaymentLog> findByUser(User user, Pageable pageable);
 
-    // 특정 결제 키(paymentKey)로 결제 내역 조회
-    List<PaymentLog> findByPaymentKey(String paymentKey);
+  // 특정 결제 키(paymentKey)로 결제 내역 조회
+  List<PaymentLog> findByPaymentKey(String paymentKey);
+
+  // 특정 사용자(userId)의 결제 로그 삭제
+  void deleteByUserId(Long userId);
 }

--- a/roome/src/main/java/com/roome/domain/payment/repository/PaymentRepository.java
+++ b/roome/src/main/java/com/roome/domain/payment/repository/PaymentRepository.java
@@ -2,22 +2,24 @@ package com.roome.domain.payment.repository;
 
 import com.roome.domain.payment.entity.Payment;
 import com.roome.domain.payment.entity.PaymentStatus;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
-    // paymentKey로 결제 정보 조회
-    Optional<Payment> findByPaymentKey(String paymentKey);
+  // paymentKey로 결제 정보 조회
+  Optional<Payment> findByPaymentKey(String paymentKey);
 
-    // orderId로 결제 정보 조회
-    Optional<Payment> findByOrderId(String orderId);
+  // orderId로 결제 정보 조회
+  Optional<Payment> findByOrderId(String orderId);
 
-    // 특정 사용자(userId)의 결제 내역 조회
-    List<Payment> findByUserId(Long userId);
+  // 특정 사용자(userId)의 결제 내역 조회
+  List<Payment> findByUserId(Long userId);
 
-    // 특정 사용자(userId)의 성공한 결제 내역 조회
-    List<Payment> findByUserIdAndStatus(Long userId, PaymentStatus status);
+  // 특정 사용자(userId)의 성공한 결제 내역 조회
+  List<Payment> findByUserIdAndStatus(Long userId, PaymentStatus status);
+
+  // 특정 사용자(userId)의 결제 데이터 삭제
+  void deleteByUserId(Long userId);
 }


### PR DESCRIPTION
## 📌 Fix: 회원 탈퇴 시 외래 키 제약 조건 문제 해결

### ✅ PR 설명
회원 탈퇴 시 결제 데이터(Payment, PaymentLog) 연관 삭제 기능을 추가해 탈퇴 시에 발생하던 외래 키 제약 조건 문제를 해결했습니다.

### 🏗 작업 내용
- [ ] TODO 1 (어떤 기능을 개발했는지)
- [ ] TODO 2 (관련 API가 있다면 명시)
- [ ] TODO 3 (테스트 여부 등)

### 📸 테스트 결과 (선택)
> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)
> 관련된 Issue가 있다면 `#이슈번호` 형식으로 작성해주세요.

### 🚨 참고 사항 (선택)
> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.
